### PR TITLE
feat: add script to copy stores and uploads to a new space

### DIFF
--- a/tools/cli.js
+++ b/tools/cli.js
@@ -45,6 +45,7 @@ cli
 
 cli
   .command('rebuild-space-metrics <space-did>', 'Rebuild store and upload metrics for a space.')
+  .option('-s, --snapshot', 'If set, create a billing snapshot after updating the space metrics.')
   .action(rebuildSpaceMetrics)
 
 cli.parse(process.argv)

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -9,6 +9,7 @@ import { printD1ProvisionsEmails } from './d1-migration/print-d1-emails.js'
 import { verifyD1DynamoMigration } from './d1-migration/verify-d1-dynamo-migration.js'
 import { getOldestPiecesPendingDeals } from './get-oldest-pieces-pending-deals.js'
 import { copyStoresAndUploadsToNewSpace } from './copy-stores-and-uploads-to-space.js'
+import { rebuildSpaceMetrics } from './rebuild-space-metrics.js'
 
 const cli = sade('w3infra-cli')
 
@@ -39,7 +40,11 @@ cli
   .action(verifyD1DynamoMigration)
 
 cli
-  .command('copy-stores-and-uploads <old-space-did> <new-space-did>')
+  .command('copy-stores-and-uploads <old-space-did> <new-space-did>', 'Copy store and upload records of old-space-did to new-space-did')
   .action(copyStoresAndUploadsToNewSpace)
+
+cli
+  .command('rebuild-space-metrics <space-did>', 'Rebuild store and upload metrics for a space.')
+  .action(rebuildSpaceMetrics)
 
 cli.parse(process.argv)

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -8,6 +8,7 @@ import { migrateFromD1ToDynamo } from './d1-migration/add-to-dynamo.js'
 import { printD1ProvisionsEmails } from './d1-migration/print-d1-emails.js'
 import { verifyD1DynamoMigration } from './d1-migration/verify-d1-dynamo-migration.js'
 import { getOldestPiecesPendingDeals } from './get-oldest-pieces-pending-deals.js'
+import { copyStoresAndUploadsToNewSpace } from './copy-stores-and-uploads-to-space.js'
 
 const cli = sade('w3infra-cli')
 
@@ -36,5 +37,9 @@ cli
 cli
   .command('verify-d1-migration', 'Verify D1 data has migrated successfully to Dynamo')
   .action(verifyD1DynamoMigration)
+
+cli
+  .command('copy-stores-and-uploads <old-space-did> <new-space-did>')
+  .action(copyStoresAndUploadsToNewSpace)
 
 cli.parse(process.argv)

--- a/tools/copy-stores-and-uploads-to-space.js
+++ b/tools/copy-stores-and-uploads-to-space.js
@@ -1,0 +1,171 @@
+import {
+  BatchWriteItemCommand,
+  DynamoDBClient,
+  QueryCommand
+} from '@aws-sdk/client-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+
+export async function copyStoresAndUploadsToNewSpace() {
+  const {
+    ENV,
+    OLD_SPACE_DID,
+    NEW_SPACE_DID
+  } = getEnv()
+
+  const { client: storeClient, tableName: storeTableName } = getDynamoDb(
+    'store',
+    ENV,
+    getRegion(ENV)
+  )
+
+  const storeRows = getAllTableRows(storeClient, storeTableName, OLD_SPACE_DID)
+  const storeResults = []
+  // this will run out of memory if things get tooooo big, but the items are very small so let's do this for now
+  for await (const row of storeRows) {
+    storeResults.push(row)
+  }
+  console.log(`Found ${storeResults.length} store rows`)
+  await updateWithNewSpaceAndPutItems(storeClient, storeTableName, storeResults, NEW_SPACE_DID)
+
+  const { client: uploadClient, tableName: uploadTableName } = getDynamoDb(
+    'upload',
+    ENV,
+    getRegion(ENV)
+  )
+
+  const uploadRows = getAllTableRows(uploadClient, uploadTableName, OLD_SPACE_DID)
+  const uploadResults = []
+  // this will run out of memory if things get tooooo big, but the items are very small so let's do this for now
+  for await (const row of uploadRows) {
+    uploadResults.push(row)
+  }
+  console.log(`Found ${uploadResults.length} upload rows`)
+  await updateWithNewSpaceAndPutItems(uploadClient, uploadTableName, uploadResults, NEW_SPACE_DID)
+}
+
+/**
+ * @template T
+ * @param {Array<T>} arr
+ * @param {number} chunkSize 
+ * @yields {Array<T>}
+ */
+function* chunks(arr, chunkSize) {
+  for (let i = 0; i < arr.length; i += chunkSize) {
+    yield arr.slice(i, i + chunkSize);
+  }
+}
+
+/**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamo
+ * @param {string} tableName
+ * @param {unknown[]} currentRows
+ * @param {string} space
+ * @param {object} [options]
+ * @param {number} [options.limit]
+ */
+export async function updateWithNewSpaceAndPutItems(dynamo, tableName, currentRows, space) {
+  // max batch size is https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb/command/BatchWriteItemCommand/
+  const MAX_BATCH_SIZE = 25
+  const updatedRows = currentRows.map(item => ({ ...item, space }))
+  for (const rows of chunks(updatedRows, MAX_BATCH_SIZE)) {
+    await dynamo.send(new BatchWriteItemCommand({
+      RequestItems: {
+        [tableName]: rows.slice(0, MAX_BATCH_SIZE).map(item => ({
+          PutRequest: {
+            Item: marshall(item)
+          }
+        }))
+      }
+    }))
+  }
+  console.log(`put ${currentRows.length} items to ${tableName}`)
+}
+
+/**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamo
+ * @param {string} tableName
+ * @param {string} space
+ * @param {object} [options]
+ * @param {number} [options.limit]
+ */
+export async function* getAllTableRows(dynamo, tableName, space, options = {}) {
+  let done = false
+  let lastEvaluatedKey
+  while (!done) {
+    const response = await dynamo.send(new QueryCommand({
+      TableName: tableName,
+      Limit: options.limit || 100000,
+      KeyConditions: {
+        space: {
+          ComparisonOperator: 'EQ',
+          AttributeValueList: [{ S: space }],
+        },
+      },
+      ExclusiveStartKey: lastEvaluatedKey
+    }))
+    for (const item of response.Items) {
+      yield unmarshall(item)
+    }
+    if (response.LastEvaluatedKey) {
+      lastEvaluatedKey = response.LastEvaluatedKey
+    } else {
+      done = true
+    }
+  }
+}
+
+/**
+ * Get Env validating it is set.
+ */
+function getEnv() {
+  return {
+    ENV: mustGetEnv('ENV'),
+    OLD_SPACE_DID: mustGetEnv('OLD_SPACE_DID'),
+    NEW_SPACE_DID: mustGetEnv('NEW_SPACE_DID'),
+  }
+}
+
+/**
+ * 
+ * @param {string} name 
+ * @returns {string}
+ */
+function mustGetEnv(name) {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing env var: ${name}`)
+  }
+
+  return value
+}
+
+/**
+ * @param {string} env
+ */
+function getRegion(env) {
+  if (env === 'staging') {
+    return 'us-east-2'
+  }
+
+  return 'us-west-2'
+}
+
+/**
+ * @param {string} tableName
+ * @param {string} env
+ * @param {string} region
+ */
+function getDynamoDb(tableName, env, region) {
+  const endpoint = `https://dynamodb.${region}.amazonaws.com`
+
+  return {
+    client: new DynamoDBClient({
+      region,
+      endpoint
+    }),
+    tableName: `${env}-w3infra-${tableName}`,
+    endpoint
+  }
+}
+
+await copyStoresAndUploadsToNewSpace()

--- a/tools/copy-stores-and-uploads-to-space.js
+++ b/tools/copy-stores-and-uploads-to-space.js
@@ -70,8 +70,6 @@ function* chunks(arr, chunkSize) {
  * @param {string} tableName
  * @param {unknown[]} currentRows
  * @param {string} space
- * @param {object} [options]
- * @param {number} [options.limit]
  */
 async function updateWithNewSpaceAndPutItems(dynamo, tableName, currentRows, space) {
   // max batch size is https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb/command/BatchWriteItemCommand/
@@ -110,7 +108,7 @@ async function* getAllTableRows(dynamo, tableName, space, options = {}) {
      */
     const response = await dynamo.send(new QueryCommand({
       TableName: tableName,
-      Limit: options.limit || 100000,
+      Limit: options.limit || 4000,
       KeyConditions: {
         space: {
           ComparisonOperator: 'EQ',

--- a/tools/copy-stores-and-uploads-to-space.js
+++ b/tools/copy-stores-and-uploads-to-space.js
@@ -11,6 +11,11 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
  * key for.
  */
 
+/**
+ * 
+ * @param {string} oldSpaceDid 
+ * @param {string} newSpaceDid 
+ */
 export async function copyStoresAndUploadsToNewSpace(oldSpaceDid, newSpaceDid) {
   console.log(oldSpaceDid, newSpaceDid)
   const {
@@ -71,7 +76,10 @@ function* chunks(arr, chunkSize) {
 async function updateWithNewSpaceAndPutItems(dynamo, tableName, currentRows, space) {
   // max batch size is https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb/command/BatchWriteItemCommand/
   const MAX_BATCH_SIZE = 25
-  const updatedRows = currentRows.map(item => ({ ...item, space }))
+  const updatedRows = currentRows.map(
+    /** @param {any} item */
+    (item) => ({ ...item, space })
+  )
   for (const rows of chunks(updatedRows, MAX_BATCH_SIZE)) {
     await dynamo.send(new BatchWriteItemCommand({
       RequestItems: {
@@ -97,6 +105,9 @@ async function* getAllTableRows(dynamo, tableName, space, options = {}) {
   let done = false
   let lastEvaluatedKey
   while (!done) {
+    /**
+     * @type {any}
+     */
     const response = await dynamo.send(new QueryCommand({
       TableName: tableName,
       Limit: options.limit || 100000,

--- a/tools/rebuild-space-metrics.js
+++ b/tools/rebuild-space-metrics.js
@@ -1,6 +1,7 @@
 import {
   BatchWriteItemCommand,
   DynamoDBClient,
+  PutItemCommand,
   QueryCommand
 } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
@@ -13,8 +14,10 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
  * sure nobody is uploading to the space.
  * 
  * @param {string} spaceDid 
+ * @param {object} [options]
+ * @param {boolean} [options.snapshot]
  */
-export async function rebuildSpaceMetrics(spaceDid) {
+export async function rebuildSpaceMetrics(spaceDid, options = {}) {
   let storeSize = 0
   let storeCount = 0
   const storeRows = tableRowsBySpace('store', spaceDid, { attributesToGet: ['size'] })
@@ -35,6 +38,64 @@ store count ${storeCount}
 store size ${storeSize}
 uploadCount ${uploadCount}`)
   await updateSpaceMetrics(spaceDid, storeCount, storeSize, uploadCount)
+
+  if (options.snapshot) {
+    console.log("new billing snapshot requested, creating...")
+    await createNewBillingSnapshot(spaceDid, storeSize)
+  }
+}
+
+function getProvider() {
+  const {
+    W3UP_ENV,
+  } = getEnv()
+
+  return W3UP_ENV === 'prod' ? 'did:web:web3.storage' : 'did:web:staging.web3.storage'
+}
+
+/**
+ * 
+ * @param {string} spaceDid 
+ */
+function getSnapshotPK(spaceDid) {
+
+  return `${getProvider()}#${spaceDid}`
+}
+
+function startOfMonthDate() {
+  const currentDate = new Date()
+  return new Date(Date.UTC(currentDate.getUTCFullYear(), currentDate.getUTCMonth(), 1, 0, 0, 0))
+}
+
+/**
+ * 
+ * @param {string} spaceDid 
+ * @param {number} storeSize 
+ */
+async function createNewBillingSnapshot(spaceDid, storeSize) {
+  const {
+    W3UP_ENV,
+  } = getEnv()
+
+  const { client: dynamo, tableName } = getDynamoDb(
+    'space-snapshot',
+    W3UP_ENV,
+    getRegion(W3UP_ENV)
+  )
+
+  await dynamo.send(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: marshall({
+        pk: getSnapshotPK(spaceDid),
+        provider: getProvider(),
+        space: spaceDid,
+        size: storeSize,
+        insertedAt: new Date().toISOString(),
+        recordedAt: startOfMonthDate().toISOString()
+      })
+    })
+  )
 }
 
 /**

--- a/tools/rebuild-space-metrics.js
+++ b/tools/rebuild-space-metrics.js
@@ -1,0 +1,202 @@
+import {
+  BatchWriteItemCommand,
+  DynamoDBClient,
+  QueryCommand
+} from '@aws-sdk/client-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+
+/**
+ * Read all upload and store rows and recalculate space metrics.
+ * 
+ * Race condition possible here - if someone adds something between the reads
+ * and writes the metrics will be wrong - only run this when you're reasonably
+ * sure nobody is uploading to the space.
+ * 
+ * @param {string} spaceDid 
+ */
+export async function rebuildSpaceMetrics(spaceDid) {
+  let storeSize = 0
+  let storeCount = 0
+  const storeRows = tableRowsBySpace('store', spaceDid, { attributesToGet: ['size'] })
+  for await (const row of storeRows) {
+    storeCount++
+    storeSize += row.size
+  }
+
+  let uploadCount = 0
+  const uploadRows = tableRowsBySpace('upload', spaceDid)
+  for await (const _ of uploadRows) {
+    uploadCount++
+  }
+
+  console.log(`updating ${spaceDid} metrics with:
+store count ${storeCount}
+store size ${storeSize}
+uploadCount ${uploadCount}`)
+  await updateSpaceMetrics(spaceDid, storeCount, storeSize, uploadCount)
+}
+
+/**
+ * 
+ * @param {string} tableName 
+ * @param {string} spaceDid 
+ * @param {object} options 
+ * @param {string[]} [options.attributesToGet]
+ * @returns 
+ */
+function tableRowsBySpace(tableName, spaceDid, options = {}) {
+  const {
+    W3UP_ENV,
+  } = getEnv()
+
+  const { client: client, tableName: fullTableName } = getDynamoDb(
+    tableName,
+    W3UP_ENV,
+    getRegion(W3UP_ENV)
+  )
+
+  return getAllTableRowsBySpace(client, fullTableName, spaceDid, options)
+}
+
+/**
+ * 
+ * @param {*} spaceDid 
+ * @param {*} storeCount 
+ * @param {*} storeSize 
+ * @param {*} uploadCount 
+ */
+async function updateSpaceMetrics(spaceDid, storeCount, storeSize, uploadCount) {
+  const {
+    W3UP_ENV,
+  } = getEnv()
+
+  const { client: dynamo, tableName } = getDynamoDb(
+    'space-metrics',
+    W3UP_ENV,
+    getRegion(W3UP_ENV)
+  )
+
+  await dynamo.send(new BatchWriteItemCommand({
+    RequestItems: {
+      [tableName]: [
+        {
+          PutRequest: {
+            Item: marshall({
+              space: spaceDid,
+              name: 'store/add-size-total',
+              value: storeSize
+            })
+          }
+        },
+        {
+          PutRequest: {
+            Item: marshall({
+              space: spaceDid,
+              name: 'store/add-total',
+              value: storeCount
+            })
+          }
+        },
+        {
+          PutRequest: {
+            Item: marshall({
+              space: spaceDid,
+              name: 'upload/add-total',
+              value: uploadCount
+            })
+          }
+        },
+      ]
+    }
+  }))
+}
+
+/**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamo
+ * @param {string} tableName
+ * @param {string} space
+ * @param {object} [options]
+ * @param {number} [options.limit]
+ * @param {string[]} [options.attributesToGet]
+ */
+async function* getAllTableRowsBySpace(dynamo, tableName, space, options = {}) {
+  let done = false
+  let lastEvaluatedKey
+  while (!done) {
+    /**
+     * @type {any}
+     */
+    const response = await dynamo.send(new QueryCommand({
+      TableName: tableName,
+      Limit: options.limit || 4000,
+      AttributesToGet: options.attributesToGet,
+      KeyConditions: {
+        space: {
+          ComparisonOperator: 'EQ',
+          AttributeValueList: [{ S: space }],
+        },
+      },
+      ExclusiveStartKey: lastEvaluatedKey
+    }))
+    for (const item of response.Items) {
+      yield unmarshall(item)
+    }
+    if (response.LastEvaluatedKey) {
+      lastEvaluatedKey = response.LastEvaluatedKey
+    } else {
+      done = true
+    }
+  }
+}
+
+/**
+ * Get Env validating it is set.
+ */
+function getEnv() {
+  return {
+    W3UP_ENV: mustGetEnv('W3UP_ENV'),
+  }
+}
+
+/**
+ * 
+ * @param {string} name 
+ * @returns {string}
+ */
+function mustGetEnv(name) {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing env var: ${name}`)
+  }
+
+  return value
+}
+
+/**
+ * @param {string} env
+ */
+function getRegion(env) {
+  if (env === 'staging') {
+    return 'us-east-2'
+  }
+
+  return 'us-west-2'
+}
+
+/**
+ * @param {string} tableName
+ * @param {string} env
+ * @param {string} region
+ */
+function getDynamoDb(tableName, env, region) {
+  const endpoint = `https://dynamodb.${region}.amazonaws.com`
+
+  return {
+    client: new DynamoDBClient({
+      region,
+      endpoint
+    }),
+    tableName: `${env}-w3infra-${tableName}`,
+    endpoint
+  }
+}

--- a/tools/rebuild-space-metrics.js
+++ b/tools/rebuild-space-metrics.js
@@ -25,6 +25,7 @@ export async function rebuildSpaceMetrics(spaceDid) {
 
   let uploadCount = 0
   const uploadRows = tableRowsBySpace('upload', spaceDid)
+  // eslint-disable-next-line no-unused-vars
   for await (const _ of uploadRows) {
     uploadCount++
   }
@@ -49,7 +50,7 @@ function tableRowsBySpace(tableName, spaceDid, options = {}) {
     W3UP_ENV,
   } = getEnv()
 
-  const { client: client, tableName: fullTableName } = getDynamoDb(
+  const { client, tableName: fullTableName } = getDynamoDb(
     tableName,
     W3UP_ENV,
     getRegion(W3UP_ENV)


### PR DESCRIPTION
There are many ways a user might lose control of a space. Because we can't fake the crypto our system is built upon, the simplest solution to this is to have them create a new space that they do control and then ask us to copy the contents of the old space into the new.

Of course this doesn't require copying bits around - we just need to update some indices in DynamoDB. This script finds all entries in the store and upload tables for a space and creates new entries for each of those items in the new space. This should result in the new space being functionally identical to the old

This is a somewhat sensitive operation - we should only do this when we trust the customer a great deal - the contents of a particular space may be sensitive and this is a potential attack vector to discover them.

This has not been tested extensively, though I have run it in my development AWS env and it seems to work - we should do some validation that using this results in a new space that is functionally identical to the old.

@alanshaw particularly interested in your thoughts on whether this will mess up billing at all?