### PR TITLE
Disable flaky filecoin test for now

### DIFF
--- a/test/filecoin.test.js
+++ b/test/filecoin.test.js
@@ -8,7 +8,6 @@ import * as raw from 'multiformats/codecs/raw'
 import { base58btc } from 'multiformats/bases/base58'
 
 import * as AgentStore from '../upload-api/stores/agent.js'
-import { useReceiptStore } from '../filecoin/store/receipt.js'
 
 import {
   getApiEndpoint,
@@ -40,7 +39,7 @@ test.before(t => {
 test('w3filecoin integration flow', async t => {
   const stage = getStage()
   const s3Client = getAwsBucketClient()
-  const s3ClientFilecoin = getAwsBucketClient('us-east-2')
+  // const s3ClientFilecoin = getAwsBucketClient('us-east-2')
   const inbox = await createMailSlurpInbox()
   const endpoint = t.context.apiEndpoint
 


### PR DESCRIPTION
# Goals

currently, seed.run PRs fail 90%+ of the time because of the Filecoin test.

until we have a more reliable way to test the filecoin flow, the PR disables it.

the inserted comment suggests a few solutions -- either spinning up custom infra for w3filecoin pipeline on each pr to get more reliable results, or mocking out the pipeline

either way, this is the temporary fix -- I don't want to put in extra retries or anything -- we just need to find a better way to test, or investigate if there are in fact underlying issues, but in the meantime, other PRs need to get merged.