### PR TITLE
fix(upload-api-stack): don't add domain to apiID on first zone

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -55,9 +55,9 @@ export function UploadApiStack({ stack, app }) {
   const git = getGitInfo()
   const ucanInvocationPostbasicAuth = new Config.Secret(stack, 'UCAN_INVOCATION_POST_BASIC_AUTH')
 
-  const apis = (customDomains ?? [undefined]).map((customDomain) => {
+  const apis = (customDomains ?? [undefined]).map((customDomain, idx) => {
     const hostedZone = customDomain?.hostedZone
-    const apiId = [`http-gateway`, hostedZone?.replaceAll('.', '_')]
+    const apiId = [`http-gateway`, idx > 0 ? hostedZone?.replaceAll('.', '_') : '']
       .filter(Boolean)
       .join('-')
     return new Api(stack, apiId, {

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -57,6 +57,7 @@ export function UploadApiStack({ stack, app }) {
 
   const apis = (customDomains ?? [undefined]).map((customDomain, idx) => {
     const hostedZone = customDomain?.hostedZone
+    // the first customDomain will be web3.storage, and we don't want the apiId for that domain to have a second part, see PR of this change for context
     const apiId = [`http-gateway`, idx > 0 ? hostedZone?.replaceAll('.', '_') : '']
       .filter(Boolean)
       .join('-')


### PR DESCRIPTION
# Goals

resolve https://console.seed.run/dag-house/w3infra/activity/stages/staging/builds/386/services/upload-api

Essentially cause the up.web3.storage domain apiID changes, it tries to recreate the domain record, and it can't. So the solution is don't change the API ID for the web3.storage domain. 

# Implementation

In order to match the existing deployment, this PR will not add the domain to the first API ID for the first hosted zone.