### PR TITLE
fix(upload-api): make text color explicit

### DIFF
--- a/upload-api/html-storacha/index.jsx
+++ b/upload-api/html-storacha/index.jsx
@@ -36,6 +36,7 @@ export function buildDocument(body) {
     }
 
     body {
+      color: black;
       background-color: var(--hot-red-light);
       font-family: 'Epilogue', sans-serif;
       max-width: 70rem;


### PR DESCRIPTION
# Goals

My storacha branded email validation page is rendering body text white and unreadable, cause it's just the browser default. Fix this

# Implementation

set text color for body text on storacha branded email validation page to black, rather than relying on browser default color