### PR TITLE
fix(config): don't force access service url

### DIFF
--- a/stacks/config.js
+++ b/stacks/config.js
@@ -178,16 +178,7 @@ export function setupSentry (app, stack) {
  * @param  {ApiDomainProps | undefined} customDomain
  */
 export function getServiceURL (stack, customDomain) {
-  // in production we use the top level subdomain
-  if (stack.stage === 'prod') {
-    return 'https://up.web3.storage'
-  // Derive from custom domain if there is one, which is used in staging, PR envs and dev envs
-  } else if (customDomain) {
-    return `https://${customDomain.domainName}`
-  // everywhere else we use something more estoteric - usually an AWS Lambda URL
-  } else {
-    return process.env.ACCESS_SERVICE_URL
-  }
+  return customDomain ? `https://${customDomain.domainName}` : process.env.ACCESS_SERVICE_URL
 }
 
 /**


### PR DESCRIPTION
# Goals

use access service url from custom domain, even in prod

# Implementation

Now that we have two domains for prod, we need to use the custom domain rather than just forcing `up.web3.storage`

This issue only applies to prod which is why it didn't come up in previous testing.