### PR TITLE
feat: add PSA stack

### DIFF
--- a/filecoin/store/invocation.js
+++ b/filecoin/store/invocation.js
@@ -8,7 +8,7 @@ import { getS3Client } from '../../lib/aws/s3.js'
  *
  * @param {string} region
  * @param {string} bucketName
- * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
+ * @param {Partial<import('../../lib/aws/s3.js').Address>} [options]
  */
 export function createInvocationStore(region, bucketName, options = {}) {
   const s3client = getS3Client({

--- a/filecoin/store/workflow.js
+++ b/filecoin/store/workflow.js
@@ -7,7 +7,7 @@ import { getS3Client } from '../../lib/aws/s3.js'
  *
  * @param {string} region
  * @param {string} bucketName
- * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
+ * @param {Partial<import('../../lib/aws/s3.js').Address>} [options]
  */
 export function createWorkflowStore(region, bucketName, options = {}) {
   const s3client = getS3Client({

--- a/filecoin/test/helpers/context.js
+++ b/filecoin/test/helpers/context.js
@@ -8,7 +8,7 @@ import anyTest from 'ava'
  *
  * @typedef {object} S3Context
  * @property {import('@aws-sdk/client-s3').S3Client} s3Client
- * @property {import('@aws-sdk/client-s3').ServiceInputTypes} s3Opts
+ * @property {import('../../../lib/aws/s3.js').Address} s3Opts
  *
  * @typedef {object} DynamoContext
  * @property {string} dbEndpoint

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "carpark",
         "filecoin",
         "indexer",
+        "psa",
         "replicator",
         "roundabout",
         "tools",
@@ -297,6 +298,19 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
       "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
     },
+    "node_modules/@aws-cdk/aws-lambda-python-alpha": {
+      "version": "2.142.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.142.1-alpha.0.tgz",
+      "integrity": "sha512-XknR1To5RJbMWR92h3VCOA+DaKnjLDgKSNrWVAdbqkrnlpB1zygWFSXQQeV38f8ySkCwbt8NaUw2Mhi3Z6w+Eg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.142.1",
+        "constructs": "^10.0.0"
+      }
+    },
     "node_modules/@aws-cdk/aws-service-spec": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-service-spec/-/aws-service-spec-0.1.4.tgz",
@@ -478,34 +492,127 @@
       }
     },
     "node_modules/@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-crypto/crc32c": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
-      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@aws-crypto/crc32c/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
@@ -521,23 +628,76 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha1-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
-      "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
@@ -1717,71 +1877,723 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.583.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.583.0.tgz",
-      "integrity": "sha512-pS7wncugSuIQ8RgtRIE9Dystdmd3mMnjfjiO1iA1UhGXkyAgoJzQ4jH0r+5X+eWmYHYQcfy9fUQXT2gqV3t9GA==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.658.1.tgz",
+      "integrity": "sha512-rxYW7ONoh1y/SM292jt0TEH+LSiztoPCJxT3gst4S2o/85apFY3RxL8TrhOqzXoIeMu2LNzyN51Zygme6AbQAA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha1-browser": "3.0.0",
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sso-oidc": "3.583.0",
-        "@aws-sdk/client-sts": "3.583.0",
-        "@aws-sdk/core": "3.582.0",
-        "@aws-sdk/credential-provider-node": "3.583.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.577.0",
-        "@aws-sdk/middleware-expect-continue": "3.577.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.577.0",
-        "@aws-sdk/middleware-host-header": "3.577.0",
-        "@aws-sdk/middleware-location-constraint": "3.577.0",
-        "@aws-sdk/middleware-logger": "3.577.0",
-        "@aws-sdk/middleware-recursion-detection": "3.577.0",
-        "@aws-sdk/middleware-sdk-s3": "3.582.0",
-        "@aws-sdk/middleware-signing": "3.577.0",
-        "@aws-sdk/middleware-ssec": "3.577.0",
-        "@aws-sdk/middleware-user-agent": "3.583.0",
-        "@aws-sdk/region-config-resolver": "3.577.0",
-        "@aws-sdk/signature-v4-multi-region": "3.582.0",
-        "@aws-sdk/types": "3.577.0",
-        "@aws-sdk/util-endpoints": "3.583.0",
-        "@aws-sdk/util-user-agent-browser": "3.577.0",
-        "@aws-sdk/util-user-agent-node": "3.577.0",
-        "@aws-sdk/xml-builder": "3.575.0",
-        "@smithy/config-resolver": "^3.0.0",
-        "@smithy/core": "^2.0.1",
-        "@smithy/eventstream-serde-browser": "^3.0.0",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.0",
-        "@smithy/eventstream-serde-node": "^3.0.0",
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/hash-blob-browser": "^3.0.0",
-        "@smithy/hash-node": "^3.0.0",
-        "@smithy/hash-stream-node": "^3.0.0",
-        "@smithy/invalid-dependency": "^3.0.0",
-        "@smithy/md5-js": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.0",
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-retry": "^3.0.1",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.658.1",
+        "@aws-sdk/client-sts": "3.658.1",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
+        "@aws-sdk/middleware-bucket-endpoint": "3.654.0",
+        "@aws-sdk/middleware-expect-continue": "3.654.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.658.1",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-location-constraint": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-sdk-s3": "3.658.1",
+        "@aws-sdk/middleware-ssec": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/signature-v4-multi-region": "3.658.1",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@aws-sdk/xml-builder": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.6",
+        "@smithy/eventstream-serde-browser": "^3.0.9",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.6",
+        "@smithy/eventstream-serde-node": "^3.0.8",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/hash-blob-browser": "^3.1.5",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/hash-stream-node": "^3.1.5",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/md5-js": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.1",
-        "@smithy/util-defaults-mode-node": "^3.0.1",
-        "@smithy/util-endpoints": "^2.0.0",
-        "@smithy/util-retry": "^3.0.0",
-        "@smithy/util-stream": "^3.0.1",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-stream": "^3.1.8",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.5",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.658.1.tgz",
+      "integrity": "sha512-lOuaBtqPTYGn6xpXlQF4LsNDsQ8Ij2kOdnk+i69Kp6yS76TYvtUuukyLL5kx8zE1c8WbYtxj9y8VNw9/6uKl7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.658.1.tgz",
+      "integrity": "sha512-RGcZAI3qEA05JszPKwa0cAyp8rnS1nUvs0Sqw4hqLNQ1kD7b7V6CPjRXe7EFQqCOMvM4kGqx0+cEEVTOmBsFLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.658.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.658.1.tgz",
+      "integrity": "sha512-yw9hc5blTnbT1V6mR7Cx9HGc9KQpcLQ1QXj8rntiJi6tIYu3aFNVEyy81JHL7NsuBSeQulJTvHO3y6r3O0sfRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.658.1",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.658.1.tgz",
+      "integrity": "sha512-vJVMoMcSKXK2gBRSu9Ywwv6wQ7tXH8VL1fqB1uVxgCqBZ3IHfqNn4zvpMPWrwgO2/3wv7XFyikGQ5ypPTCw4jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/signature-v4": "^4.1.4",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.654.0.tgz",
+      "integrity": "sha512-kogsx3Ql81JouHS7DkheCDU9MYAvK0AokxjcshDveGmf7BbgbWCA8Fnb9wjQyNDaOXNvkZu8Z8rgkX91z324/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.658.1.tgz",
+      "integrity": "sha512-4ubkJjEVCZflxkZnV1JDQv8P2pburxk1LrEp55telfJRzXrnowzBKwuV2ED0QMNC448g2B3VCaffS+Ct7c4IWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-stream": "^3.1.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.658.1.tgz",
+      "integrity": "sha512-2uwOamQg5ppwfegwen1ddPu5HM3/IBSnaGlaKLFhltkdtZ0jiqTZWUtX2V+4Q+buLnT0hQvLS/frQ+7QUam+0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.658.1",
+        "@aws-sdk/credential-provider-process": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.658.1",
+        "@aws-sdk/credential-provider-web-identity": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.658.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.658.1.tgz",
+      "integrity": "sha512-XwxW6N+uPXPYAuyq+GfOEdfL/MZGAlCSfB5gEWtLBFmFbikhmEuqfWtI6CD60OwudCUOh6argd21BsJf8o1SJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.658.1",
+        "@aws-sdk/credential-provider-ini": "3.658.1",
+        "@aws-sdk/credential-provider-process": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.658.1",
+        "@aws-sdk/credential-provider-web-identity": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.654.0.tgz",
+      "integrity": "sha512-PmQoo8sZ9Q2Ow8OMzK++Z9lI7MsRUG7sNq3E72DVA215dhtTICTDQwGlXH2AAmIp7n+G9LLRds+4wo2ehG4mkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.658.1.tgz",
+      "integrity": "sha512-YOagVEsZEk9DmgJEBg+4MBXrPcw/tYas0VQ5OVBqC5XHNbi2OBGJqgmjVPesuu393E7W0VQxtJFDS00O1ewQgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.658.1",
+        "@aws-sdk/token-providers": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.654.0.tgz",
+      "integrity": "sha512-6a2g9gMtZToqSu+CusjNK5zvbLJahQ9di7buO3iXgbizXpLXU1rnawCpWxwslMpT5fLgMSKDnKDrr6wdEk7jSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.654.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.654.0.tgz",
+      "integrity": "sha512-rxGgVHWKp8U2ubMv+t+vlIk7QYUaRCHaVpmUlJv0Wv6Q0KeO9a42T9FxHphjOTlCGQOLcjCreL9CF8Qhtb4mdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.654.0.tgz",
+      "integrity": "sha512-OQYb+nWlmASyXfRb989pwkJ9EVUMP1CrKn2eyTk3usl20JZmKo2Vjis6I0tLUkMSxMhnBJJlQKyWkRpD/u1FVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.654.0.tgz",
+      "integrity": "sha512-gKSomgltKVmsT8sC6W7CrADZ4GHwX9epk3GcH6QhebVO3LA9LRbkL3TwOPUXakxxOLLUTYdOZLIOtFf7iH00lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.658.1.tgz",
+      "integrity": "sha512-UdiwCY4Eg7e1ZbseKvBr83SARukcqS5R9R3bnx4sb3cEK0wFDXWrlhRMgK94jr8IJeskV1ySyxozdb1XOzOU3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/core": "^2.4.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/signature-v4": "^4.1.4",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-stream": "^3.1.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.654.0.tgz",
+      "integrity": "sha512-liCcqPAyRsr53cy2tYu4qeH4MMN0eh9g6k56XzI5xd4SghXH5YWh4qOYAlQ8T66ZV4nPMtD8GLtLXGzsH8moFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.654.0.tgz",
+      "integrity": "sha512-ydGOrXJxj3x0sJhsXyTmvJVLAE0xxuTWFJihTl67RtaO7VRNtd82I3P3bwoMMaDn5WpmV5mPo8fEUDRlBm3fPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.658.1.tgz",
+      "integrity": "sha512-gad2cOtmwLuiR096PB1vJsv2+KYwI+eN5D+eLaRLCTD9MMGvVWB5xkIXXGmn99ks4gAgtSpzZp8RD6viBj0gIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.658.1",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/signature-v4": "^4.1.4",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.654.0.tgz",
+      "integrity": "sha512-D8GeJYmvbfWkQDtTB4owmIobSMexZel0fOoetwvgCQ/7L8VPph3Q2bn1TRRIXvH7wdt6DcDxA3tKMHPBkT3GlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.654.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.654.0.tgz",
+      "integrity": "sha512-i902fcBknHs0Irgdpi62+QMvzxE+bczvILXigYrlHL4+PiEnlMVpni5L5W1qCkNZXf8AaMrSBuR1NZAGp6UOUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-endpoints": "^2.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.654.0.tgz",
+      "integrity": "sha512-ykYAJqvnxLt7wfrqya28wuH3/7NdrwzfiFd7NqEVQf7dXVxL5RPEpD7DxjcyQo3DsHvvdUvGZVaQhozycn1pzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.654.0.tgz",
+      "integrity": "sha512-a0ojjdBN6pqv6gB4H/QPPSfhs7mFtlVwnmKCM/QrTaFzN0U810PJ1BST3lBx5sa23I5jWHGaoFY+5q65C3clLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/signature-v4": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.4.tgz",
+      "integrity": "sha512-72MiK7xYukNsnLJI9NqvUHqTu0ziEsfMsYNlWpiJfuGQnCTFKpckThlEatirvcA/LmT1h7rRO+pJD06PYsPu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
@@ -2830,16 +3642,30 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.577.0.tgz",
-      "integrity": "sha512-twlkNX2VofM6kHXzDEiJOiYCc9tVABe5cbyxMArRWscIsCWG9mamPhC77ezG4XsN9dFEwVdxEYD5Crpm/5EUiw==",
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.654.0.tgz",
+      "integrity": "sha512-/lWkyeLESiK+rAB4+NCw1cVPle9RN7RW/v7B4b8ORiCn1FwZLUPmEiZSYzyh4in5oa3Mri+W/g+KafZDH6LCbA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/types": "3.654.0",
         "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2875,13 +3701,27 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.577.0.tgz",
-      "integrity": "sha512-6dPp8Tv4F0of4un5IAyG6q++GrRrNQQ4P2NAMB1W0VO4JoEu1C8GievbbDLi88TFIFmtKpnHB0ODCzwnoe8JsA==",
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.654.0.tgz",
+      "integrity": "sha512-S7fSlo8vdjkQTy9DmdF54ZsPwc+aA4z5Y9JVqAlGL9QiZe/fPtRE3GZ8BBbMICjBfMEa12tWjzhDz9su2c6PIA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2889,17 +3729,33 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.577.0.tgz",
-      "integrity": "sha512-IHAUEipIfagjw92LV8SOSBiCF7ZnqfHcw14IkcZW2/mfrCy1Fh/k40MoS/t3Tro2tQ91rgQPwUoSgB/QCi2Org==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.658.1.tgz",
+      "integrity": "sha512-aBhnDIy8PwhgZRJh5U4l1JfLIPLkBeHBCTwn3XjdvhvisXNCfeINWKYuDDHamM+XKgBNUlLoTxpXI2AvLk5cGw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.577.0",
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-sdk/types": "3.654.0",
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
         "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2921,12 +3777,26 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.577.0.tgz",
-      "integrity": "sha512-DKPTD2D2s+t2QUo/IXYtVa/6Un8GZ+phSTBkyBNx2kfZz4Kwavhl/JJzSqTV3GfCXkVdFu7CrjoX7BZ6qWeTUA==",
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.654.0.tgz",
+      "integrity": "sha512-Duvv5c4DEQ7P6c0YlcvEUW3xCJi6X2uktafNGjILhVDMQwShSF/aFqNv/ikWU/luQcmWHZ9DtDjTR9UKLh6eTA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3118,12 +3988,26 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.577.0.tgz",
-      "integrity": "sha512-i2BPJR+rp8xmRVIGc0h1kDRFcM2J9GnClqqpc+NLSjmYadlcg4mPklisz9HzwFVcRPJ5XcGf3U4BYs5G8+iTyg==",
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.654.0.tgz",
+      "integrity": "sha512-k7hkQDJh4hcRJC7YojQ11kc37SY4foryen26Eafj5qYjeG2OGMW0oZTJDl1TVFJ7AcCjqIuMIo0Ho2US/2JspQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3162,21 +4046,139 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.583.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.583.0.tgz",
-      "integrity": "sha512-Xp48RdnUzERYraIczByhbV/92TtXeJNE7QXOyMGVdvQkVP+3rwuXRGg85FqNSkOq7TFaGhnuxPiYWvsTeEzZTg==",
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.658.1.tgz",
+      "integrity": "sha512-FQsECwePc34AAZU2mt0GUOppUIwOCLdsBkDQdCDyLDuWMN1+caYVzSAu++pJpkA+1MDdAKp4AiJyNiWbe/uI5g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.582.0",
-        "@aws-sdk/types": "3.577.0",
-        "@aws-sdk/util-format-url": "3.577.0",
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/signature-v4-multi-region": "3.658.1",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-format-url": "3.654.0",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/core": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.658.1.tgz",
+      "integrity": "sha512-vJVMoMcSKXK2gBRSu9Ywwv6wQ7tXH8VL1fqB1uVxgCqBZ3IHfqNn4zvpMPWrwgO2/3wv7XFyikGQ5ypPTCw4jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/signature-v4": "^4.1.4",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.658.1.tgz",
+      "integrity": "sha512-UdiwCY4Eg7e1ZbseKvBr83SARukcqS5R9R3bnx4sb3cEK0wFDXWrlhRMgK94jr8IJeskV1ySyxozdb1XOzOU3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/core": "^2.4.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/signature-v4": "^4.1.4",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-stream": "^3.1.8",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.658.1.tgz",
+      "integrity": "sha512-gad2cOtmwLuiR096PB1vJsv2+KYwI+eN5D+eLaRLCTD9MMGvVWB5xkIXXGmn99ks4gAgtSpzZp8RD6viBj0gIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.658.1",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/signature-v4": "^4.1.4",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/signature-v4": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.4.tgz",
+      "integrity": "sha512-72MiK7xYukNsnLJI9NqvUHqTu0ziEsfMsYNlWpiJfuGQnCTFKpckThlEatirvcA/LmT1h7rRO+pJD06PYsPu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/signature-v4-crt": {
@@ -3484,13 +4486,27 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.577.0.tgz",
-      "integrity": "sha512-SyEGC2J+y/krFRuPgiF02FmMYhqbiIkOjDE6k4nYLJQRyS6XEAGxZoG+OHeOVEM+bsDgbxokXZiM3XKGu6qFIg==",
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.654.0.tgz",
+      "integrity": "sha512-2yAlJ/l1uTJhS52iu4+/EvdIyQhDBL+nATY8rEjFI0H+BHGVrJIH2CL4DByhvi2yvYwsqQX0HYah6pF/yoXukA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3550,11 +4566,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.575.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.575.0.tgz",
-      "integrity": "sha512-cWgAwmbFYNCFzPwxL705+lWps0F3ZvOckufd2KKoEZUmtpVw9/txUXNrPySUXSmRTSRhoatIMABNfStWR043bQ==",
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.654.0.tgz",
+      "integrity": "sha512-qA2diK3d/ztC8HUb7NwPKbJRV01NpzTzxFn+L5G3HzJBNeKbjLcprQ/9uG9gp2UEx2Go782FI1ddrMNa0qBICA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9727,11 +10744,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.0.tgz",
-      "integrity": "sha512-XOm4LkuC0PsK1sf2bBJLIlskn5ghmVxiEBVlo/jg0R8hxASBKYYgOoJEhKWgOr4vWGkN+5rC+oyBAqHYtxjnwQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.4.tgz",
+      "integrity": "sha512-VupaALAQlXViW3/enTf/f5l5JZYSAxoJL7f0nanhNNKnww6DGCg1oYIuNP78KDugnkwthBO6iEcym16HhWV8RQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9742,6 +10760,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
       "integrity": "sha512-sbnURCwjF0gSToGlsBiAmd1lRCmSn72nu9axfJu5lIx6RUEgHu6GwTMbqCdhQSi0Pumcm5vFxsi9XWXb2mTaoA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       }
@@ -9750,20 +10769,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.0.tgz",
       "integrity": "sha512-VDkpCYW+peSuM4zJip5WDfqvg2Mo/e8yxOv3VF1m11y7B8KKMKVFtmZWDe36Fvk8rGuWrPZHHXZ7rR7uM5yWyg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.3.tgz",
-      "integrity": "sha512-4wHqCMkdfVDP4qmr4fVPYOFOH+vKhOv3X4e6KEU9wIC8xXUQ24tnF4CW+sddGDX1zU86GGyQ7A+rg2xmUD6jpQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.8.tgz",
+      "integrity": "sha512-Tv1obAC18XOd2OnDAjSWmmthzx6Pdeh63FbLin8MlPiuJ2ATpKkq0NcNOJFr0dO+JmZXnwu8FQxKJ3TKJ3Hulw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.2",
-        "@smithy/types": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.2",
+        "@smithy/util-middleware": "^3.0.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9771,17 +10792,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.3.tgz",
-      "integrity": "sha512-SpyLOL2vgE6sUYM6nQfu82OirCPkCDKctyG3aMgjMlDPTJpUlmlNH0ttu9ZWwzEjrzzr8uABmPjJTRI7gk1HFQ==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.6.tgz",
+      "integrity": "sha512-6lQQp99hnyuNNIzeTYSzCUXJHwvvFLY7hfdFGSJM95tjRDJGfzWYFRBXPaM9766LiiTsQ561KErtbufzUFSYUg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.3",
-        "@smithy/middleware-retry": "^3.0.6",
-        "@smithy/middleware-serde": "^3.0.2",
-        "@smithy/protocol-http": "^4.0.2",
-        "@smithy/smithy-client": "^3.1.4",
-        "@smithy/types": "^3.2.0",
-        "@smithy/util-middleware": "^3.0.2",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9789,14 +10813,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.2.tgz",
-      "integrity": "sha512-gqVmUaNoeqyrOAjgZg+rTmFLsphh/vS59LCMdFfVpthVS0jbfBzvBmEPktBd+y9ME4DYMGHFAMSYJDK8q0noOQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.3.tgz",
+      "integrity": "sha512-VoxMzSzdvkkjMJNE38yQgx4CfnmT+Z+5EUXkg4x7yag93eQkVQgZvN3XBSHC/ylfBbLbAtdu7flTCChX9I+mVg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.2",
-        "@smithy/property-provider": "^3.1.2",
-        "@smithy/types": "^3.2.0",
-        "@smithy/url-parser": "^3.0.2",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9804,23 +10829,25 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.0.0.tgz",
-      "integrity": "sha512-PUtyEA0Oik50SaEFCZ0WPVtF9tz/teze2fDptW6WRXl+RrEenH8UbEjudOz8iakiMl3lE3lCVqYf2Y+znL8QFQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.5.tgz",
+      "integrity": "sha512-6pu+PT2r+5ZnWEV3vLV1DzyrpJ0TmehQlniIDCSpZg6+Ji2SfOI38EqUyQ+O8lotVElCrfVc9chKtSMe9cmCZQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.0.tgz",
-      "integrity": "sha512-NB7AFiPN4NxP/YCAnrvYR18z2/ZsiHiF7VtG30gshO9GbFrIb1rC8ep4NGpJSWrz6P64uhPXeo4M0UsCLnZKqw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.9.tgz",
+      "integrity": "sha512-PiQLo6OQmZAotJweIcObL1H44gkvuJACKMNqpBBe5Rf2Ax1DOcGi/28+feZI7yTe1ERHlQQaGnm8sSkyDUgsMg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/eventstream-serde-universal": "^3.0.8",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9828,11 +10855,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.0.tgz",
-      "integrity": "sha512-RUQG3vQ3LX7peqqHAbmayhgrF5aTilPnazinaSGF1P0+tgM3vvIRWPHmlLIz2qFqB9LqFIxditxc8O2Z6psrRw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.6.tgz",
+      "integrity": "sha512-iew15It+c7WfnVowWkt2a7cdPp533LFJnpjDQgfZQcxv2QiOcyEcea31mnrk5PVbgo0nNH3VbYGq7myw2q/F6A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9840,12 +10868,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.0.tgz",
-      "integrity": "sha512-baRPdMBDMBExZXIUAoPGm/hntixjt/VFpU6+VmCyiYJYzRHRxoaI1MN+5XE+hIS8AJ2GCHLMFEIOLzq9xx1EgQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.8.tgz",
+      "integrity": "sha512-6m+wI+fT0na+6oao6UqALVA38fsScCpoG5UO/A8ZSyGLnPM2i4MS1cFUhpuALgvLMxfYoTCh7qSeJa0aG4IWpQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/eventstream-serde-universal": "^3.0.8",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9853,12 +10882,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.0.tgz",
-      "integrity": "sha512-HNFfShmotWGeAoW4ujP8meV9BZavcpmerDbPIjkJbxKbN8RsUcpRQ/2OyIxWNxXNH2GWCAxuSB7ynmIGJlQ3Dw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.8.tgz",
+      "integrity": "sha512-09tqzIQ6e+7jLqGvRji1yJoDbL/zob0OFhq75edgStWErGLf16+yI5hRc/o9/YAybOhUZs/swpW2SPn892G5Gg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/eventstream-codec": "^3.1.5",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9866,34 +10896,37 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.1.0.tgz",
-      "integrity": "sha512-s7oQjEOUH9TYjctpITtWF4qxOdg7pBrP9eigEQ8SBsxF3dRFV0S28pGMllC83DUr7ECmErhO/BUwnULfoNhKgQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.8.tgz",
+      "integrity": "sha512-Lqe0B8F5RM7zkw//6avq1SJ8AfaRd3ubFUS1eVp5WszV7p6Ne5hQ4dSuMHDpNRPhgTvj4va9Kd/pcVigHEHRow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.2",
-        "@smithy/querystring-builder": "^3.0.2",
-        "@smithy/types": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.0.0.tgz",
-      "integrity": "sha512-/Wbpdg+bwJvW7lxR/zpWAc1/x/YkcqguuF2bAzkJrvXriZu1vm8r+PUdE4syiVwQg7PPR2dXpi3CLBb9qRDaVQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.5.tgz",
+      "integrity": "sha512-Vi3eoNCmao4iKglS80ktYnBOIqZhjbDDwa1IIbF/VaJ8PsHnZTQ5wSicicPrU7nTI4JPFn92/txzWkh4GlK18Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/chunked-blob-reader": "^3.0.0",
         "@smithy/chunked-blob-reader-native": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.2.tgz",
-      "integrity": "sha512-43uGA6o6QJQdXwAogybdTDHDd3SCdKyoiHIHb8PpdE2rKmVicjG9b1UgVwdgO8QPytmVqHFaUw27M3LZKwu8Yg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.6.tgz",
+      "integrity": "sha512-c/FHEdKK/7DU2z6ZE91L36ahyXWayR3B+FzELjnYq7wH5YqIseM24V+pWCS9kFn1Ln8OFGTf+pyYPiHZuX0s/Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -9903,11 +10936,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.0.0.tgz",
-      "integrity": "sha512-J0i7de+EgXDEGITD4fxzmMX8CyCNETTIRXlxjMiNUvvu76Xn3GJ31wQR85ynlPk2wI1lqoknAFJaD1fiNDlbIA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.5.tgz",
+      "integrity": "sha512-61CyFCzqN3VBfcnGX7mof/rkzLb8oHjm4Lr6ZwBIRpBssBb8d09ChrZAqinP2rUrA915BRNkq9NpJz18N7+3hQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -9916,11 +10950,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.2.tgz",
-      "integrity": "sha512-+BAY3fMhomtq470tswXyrdVBSUhiLuhBVT+rOmpbz5e04YX+s1dX4NxTLzZGwBjCpeWZNtTxP8zbIvvFk81gUg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.6.tgz",
+      "integrity": "sha512-czM7Ioq3s8pIXht7oD+vmgy4Wfb4XavU/k/irO8NdXFFOx7YAlsCCcKOh/lJD1mJSYQqiR7NmpZ9JviryD/7AQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       }
     },
@@ -9936,22 +10971,24 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.2.tgz",
-      "integrity": "sha512-WlSK9br7fkVucTkCXporwuOttCR3cJ1GV70J8ENYXGNc0nUTPzMdWCyHztgnbbKoekVMjGZOEu+8I52nOdzqwQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.6.tgz",
+      "integrity": "sha512-Ze690T8O3M5SVbb70WormwrKzVf9QQRtIuxtJDgpUQDkmt+PtdYDetBbyCbF9ryupxLw6tgzWKgwffAShhVIXQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.2.tgz",
-      "integrity": "sha512-/Havz3PkYIEmwpqkyRTR21yJsWnFbD1ec4H1pUL+TkDnE7RCQkAVUQepLL/UeCaZeCBXvfdoKbOjSbV01xIinQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.8.tgz",
+      "integrity": "sha512-VuyszlSO49WKh3H9/kIO2kf07VUwGV80QRiaDxUfP8P8UKlokz381ETJvwLhwuypBYhLymCYyNhB3fLAGBX2og==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.2",
-        "@smithy/types": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9959,16 +10996,17 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.3.tgz",
-      "integrity": "sha512-ARAXHodhj4tttKa9y75zvENdSoHq6VGsSi7XS3+yLutrnxttJs6N10UMInCC1yi3/bopT8xug3iOP/y9R6sKJQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.3.tgz",
+      "integrity": "sha512-KeM/OrK8MVFUsoJsmCN0MZMVPjKKLudn13xpgwIMpGTYpA8QZB2Xq5tJ+RE6iu3A6NhOI4VajDTwBsm8pwwrhg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.2",
-        "@smithy/node-config-provider": "^3.1.2",
-        "@smithy/shared-ini-file-loader": "^3.1.2",
-        "@smithy/types": "^3.2.0",
-        "@smithy/url-parser": "^3.0.2",
-        "@smithy/util-middleware": "^3.0.2",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9976,17 +11014,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.6.tgz",
-      "integrity": "sha512-ICsFKp8eAyIMmxN5UT3IU37S6886L879TKtgxPsn/VD/laYNwqTLmJaCAn5//+2fRIrV0dnHp6LFlMwdXlWoUQ==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.21.tgz",
+      "integrity": "sha512-/h0fElV95LekVVEJuSw+aI11S1Y3zIUwBc6h9ZbUv43Gl2weXsbQwjLoet6j/Qtb0phfrSxS6pNg6FqgJOWZkA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.2",
-        "@smithy/protocol-http": "^4.0.2",
-        "@smithy/service-error-classification": "^3.0.2",
-        "@smithy/smithy-client": "^3.1.4",
-        "@smithy/types": "^3.2.0",
-        "@smithy/util-middleware": "^3.0.2",
-        "@smithy/util-retry": "^3.0.2",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -9995,11 +11034,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.2.tgz",
-      "integrity": "sha512-oT2abV5zLhBucJe1LIIFEcRgIBDbZpziuMPswTMbBQNcaEUycLFvX63zsFmqfwG+/ZQKsNx+BSE8W51CMuK7Yw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.6.tgz",
+      "integrity": "sha512-KKTUSl1MzOM0MAjGbudeaVNtIDo+PpekTBkCNwvfZlKndodrnvRo+00USatiyLOc0ujjO9UydMRu3O9dYML7ag==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10007,11 +11047,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.2.tgz",
-      "integrity": "sha512-6fRcxomlNKBPIy/YjcnC7YHpMAjRvGUYlYVJAfELqZjkW0vQegNcImjY7T1HgYA6u3pAcCxKVBLYnkTw8z/l0A==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.6.tgz",
+      "integrity": "sha512-2c0eSYhTQ8xQqHMcRxLMpadFbTXg6Zla5l0mwNftFCZMQmuhI7EbAJMx6R5eqfuV3YbJ3QGyS3d5uSmrHV8Khg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10019,13 +11060,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.2.tgz",
-      "integrity": "sha512-388fEAa7+6ORj/BDC70peg3fyFBTTXJyXfXJ0Bwd6FYsRltePr2oGzIcm5AuC1WUSLtZ/dF+hYOnfTMs04rLvA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.7.tgz",
+      "integrity": "sha512-g3mfnC3Oo8pOI0dYuPXLtdW1WGVb3bR2tkV21GNkm0ZvQjLTtamXAwCWt/FCb0HGvKt3gHHmF1XerG0ICfalOg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.2",
-        "@smithy/shared-ini-file-loader": "^3.1.2",
-        "@smithy/types": "^3.2.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10033,14 +11075,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.0.tgz",
-      "integrity": "sha512-pOpgB6B+VLXLwAyyvRz+ZAVXABlbAsJ2xvn3WZvrppAPImxwQOPFbeSUzWYMhpC8Tr7yQ3R8fG990QDhskkf1Q==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.3.tgz",
+      "integrity": "sha512-/gcm5DJ3k1b1zEInzBGAZC8ntJ+jwrz1NcSIu+9dSXd1FfG0G6QgkDI40tt8/WYUbHtLyo8fEqtm2v29koWo/w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.0",
-        "@smithy/protocol-http": "^4.0.2",
-        "@smithy/querystring-builder": "^3.0.2",
-        "@smithy/types": "^3.2.0",
+        "@smithy/abort-controller": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10048,11 +11091,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.2.tgz",
-      "integrity": "sha512-Hzp32BpeFFexBpO1z+ts8okbq/VLzJBadxanJAo/Wf2CmvXMBp6Q/TLWr7Js6IbMEcr0pDZ02V3u1XZkuQUJaA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.6.tgz",
+      "integrity": "sha512-NK3y/T7Q/Bw+Z8vsVs9MYIQ5v7gOX7clyrXcwhhIBQhbPgRl6JDrZbusO9qWDhcEus75Tg+VCxtIRfo3H76fpw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10060,11 +11104,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.2.tgz",
-      "integrity": "sha512-X/90xNWIOqSR2tLUyWxVIBdatpm35DrL44rI/xoeBWUuanE0iyCXJpTcnqlOpnEzgcu0xCKE06+g70TTu2j7RQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.3.tgz",
+      "integrity": "sha512-GcbMmOYpH9iRqtC05RbRnc/0FssxSTHlmaNhYBTgSgNCYpdR3Kt88u5GAZTBmouzv+Zlj/VRv92J9ruuDeJuEw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10072,11 +11117,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.2.tgz",
-      "integrity": "sha512-xhv1+HacDYsOLdNt7zW+8Fe779KYAzmWvzs9bC5NlKM8QGYCwwuFwDBynhlU4D5twgi2pZ14Lm4h6RiAazCtmA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.6.tgz",
+      "integrity": "sha512-sQe08RunoObe+Usujn9+R2zrLuQERi3CWvRO3BvnoWSYUaIrLKuAIeY7cMeDax6xGyfIP3x/yFWbEKSXvOnvVg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -10085,11 +11131,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.2.tgz",
-      "integrity": "sha512-C5hyRKgrZGPNh5QqIWzXnW+LXVrPmVQO0iJKjHeb5v3C61ZkP9QhrKmbfchcTyg/VnaE0tMNf/nmLpQlWuiqpg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.6.tgz",
+      "integrity": "sha512-UJKw4LlEkytzz2Wq+uIdHf6qOtFfee/o7ruH0jF5I6UAuU+19r9QV7nU3P/uI0l6+oElRHmG/5cBBcGJrD7Ozg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10097,22 +11144,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.2.tgz",
-      "integrity": "sha512-cu0WV2XRttItsuXlcM0kq5MKdphbMMmSd2CXF122dJ75NrFE0o7rruXFGfxAp3BKzgF/DMxX+PllIA/cj4FHMw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.6.tgz",
+      "integrity": "sha512-53SpchU3+DUZrN7J6sBx9tBiCVGzsib2e4sc512Q7K9fpC5zkJKs6Z9s+qbMxSYrkEkle6hnMtrts7XNkMJJMg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0"
+        "@smithy/types": "^3.4.2"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.2.tgz",
-      "integrity": "sha512-tgnXrXbLMO8vo6VeuqabMw/eTzQHlLmZx0TC0TjtjJghnD0Xl4pEnJtBjTJr6XF5fHMNrt5BcczDXHJT9yNQnA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.7.tgz",
+      "integrity": "sha512-IA4K2qTJYXkF5OfVN4vsY1hfnUZjaslEE8Fsr/gGFza4TAC2A9NfnZuSY2srQIbt9bwtjHiAayrRVgKse4Q7fA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10137,15 +11186,16 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.4.tgz",
-      "integrity": "sha512-y6xJROGrIoitjpwXLY7P9luDHvuT9jWpAluliuSFdBymFxcl6iyQjo9U/JhYfRHFNTruqsvKOrOESVuPGEcRmQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.5.tgz",
+      "integrity": "sha512-7IZi8J3Dr9n3tX+lcpmJ/5tCYIqoXdblFBaPuv0SEKZFRpCxE+TqIWL6I3t7jLlk9TWu3JSvEZAhtjB9yvB+zA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.2",
-        "@smithy/protocol-http": "^4.0.2",
-        "@smithy/types": "^3.2.0",
-        "@smithy/util-stream": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-stream": "^3.1.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10153,9 +11203,10 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.2.0.tgz",
-      "integrity": "sha512-cKyeKAPazZRVqm7QPvcPD2jEIt2wqDPAL1KJKb0f/5I7uhollvsWZuZKLclmyP6a+Jwmr3OV3t+X0pZUUHS9BA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
+      "integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -10164,12 +11215,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.2.tgz",
-      "integrity": "sha512-pRiPHrgibeAr4avtXDoBHmTLtthwA4l8jKYRfZjNgp+bBPyxDMPRg2TMJaYxqbKemvrOkHu9MIBTv2RkdNfD6w==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.6.tgz",
+      "integrity": "sha512-47Op/NU8Opt49KyGpHtVdnmmJMsp2hEwBdyjuFB9M2V5QVOwA7pBhhxKN5z6ztKGrMw76gd8MlbPuzzvaAncuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.2",
-        "@smithy/types": "^3.2.0",
+        "@smithy/querystring-parser": "^3.0.6",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       }
     },
@@ -10229,13 +11281,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.6.tgz",
-      "integrity": "sha512-tAgoc++Eq+KL7g55+k108pn7nAob3GLWNEMbXhZIQyBcBNaE/o3+r4AEbae0A8bWvLRvArVsjeiuhMykGa04/A==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.21.tgz",
+      "integrity": "sha512-M/FhTBk4c/SsB91dD/M4gMGfJO7z/qJaM9+XQQIqBOf4qzZYMExnP7R4VdGwxxH8IKMGW+8F0I4rNtVRrcfPoA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.4",
-        "@smithy/types": "^3.2.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -10244,16 +11297,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.6.tgz",
-      "integrity": "sha512-UNerul6/E8aiCyFTBHk+RSIZCo7m96d/N5K3FeO/wFeZP6oy5HAicLzxqa85Wjv7MkXSxSySX29L/LwTV/QMag==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.21.tgz",
+      "integrity": "sha512-NiLinPvF86U3S2Pdx/ycqd4bnY5dmFSPNL5KYRwbNjqQFS09M5Wzqk8BNk61/47xCYz1X/6KeiSk9qgYPTtuDw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.3",
-        "@smithy/credential-provider-imds": "^3.1.2",
-        "@smithy/node-config-provider": "^3.1.2",
-        "@smithy/property-provider": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.4",
-        "@smithy/types": "^3.2.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10261,12 +11315,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.3.tgz",
-      "integrity": "sha512-Dyi+pfLglDHSGsKSYunuUUSFM5V0tz7UDgv1Ex97yg+Xkn0Eb0rH0rcvl1n0MaJ11fac3HKDOH0DkALyQYCQag==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.2.tgz",
+      "integrity": "sha512-FEISzffb4H8DLzGq1g4MuDpcv6CIG15fXoQzDH9SjpRJv6h7J++1STFWWinilG0tQh9H1v2UKWG19Jjr2B16zQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.2",
-        "@smithy/types": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10285,11 +11340,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.2.tgz",
-      "integrity": "sha512-7WW5SD0XVrpfqljBYzS5rLR+EiDzl7wCVJZ9Lo6ChNFV4VYDk37Z1QI5w/LnYtU/QKnSawYoHRd7VjSyC8QRQQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.6.tgz",
+      "integrity": "sha512-BxbX4aBhI1O9p87/xM+zWy0GzT3CEVcXFPBRDoHAM+pV0eSW156pR+PSYEz0DQHDMYDsYAflC2bQNz2uaDBUZQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.2.0",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10297,12 +11353,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.2.tgz",
-      "integrity": "sha512-HUVOb1k8p/IH6WFUjsLa+L9H1Zi/FAAB2CDOpWuffI1b2Txi6sknau8kNfC46Xrt39P1j2KDzCE1UlLa2eW5+A==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.6.tgz",
+      "integrity": "sha512-BRZiuF7IwDntAbevqMco67an0Sr9oLQJqqRCsSPZZHYRnehS0LHDAkJk/pSmI7Z8c/1Vet294H7fY2fWUgB+Rg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.2",
-        "@smithy/types": "^3.2.0",
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10310,13 +11367,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.4.tgz",
-      "integrity": "sha512-CcMioiaOOsEVdb09pS7ux1ij7QcQ2jE/cE1+iin1DXMeRgAEQN/47m7Xztu7KFQuQsj0A5YwB2UN45q97CqKCg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.8.tgz",
+      "integrity": "sha512-hoKOqSmb8FD3WLObuB5hwbM7bNIWgcnvkThokTvVq7J5PKjlLUK5qQQcB9zWLHIoSaIlf3VIv2OxZY2wtQjcRQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.1.0",
-        "@smithy/node-http-handler": "^3.1.0",
-        "@smithy/types": "^3.2.0",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/types": "^3.4.2",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -10351,12 +11409,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.0.tgz",
-      "integrity": "sha512-5OVcC5ZcmmutY208ADY/l2eB4H4DVXs+hPUo/M1spF4/YEmF9DdLkfwBvohej2dIeVJayKY7hMlD0X8j3F3/Uw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.5.tgz",
+      "integrity": "sha512-jYOSvM3H6sZe3CHjzD2VQNCjWBJs+4DbtwBMvUp9y5EnnwNa7NQxTeYeQw0CKCAdGGZ3QvVkyJmvbvs5M/B10A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.0",
-        "@smithy/types": "^3.2.0",
+        "@smithy/abort-controller": "^3.1.4",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11520,6 +12579,10 @@
     },
     "node_modules/@web3-storage/w3infra-indexer": {
       "resolved": "indexer",
+      "link": true
+    },
+    "node_modules/@web3-storage/w3infra-psa": {
+      "resolved": "psa",
       "link": true
     },
     "node_modules/@web3-storage/w3infra-replicator": {
@@ -22009,9 +23072,10 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.1.tgz",
-      "integrity": "sha512-JiptvwMmlxlzIlLLwhCi/srf/nk409UL0eUBr0kioRJq15hqqKyg68iftrBvhCRjR6Rw4fkNnSc4ZJXJDuta/Q=="
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.0.tgz",
+      "integrity": "sha512-CBiqvsufgmpo01VT5ze94O+uc+Pbf6f/sThlvWss0sBZmAOu6GQn5usrYV2sf2mr17FWYc0rO8c/CNe2T90QAA==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/multihashes": {
       "version": "4.0.3",
@@ -23039,6 +24103,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -25645,18 +26715,6 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/sst/node_modules/@aws-cdk/aws-lambda-python-alpha": {
-      "version": "2.142.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.142.1-alpha.0.tgz",
-      "integrity": "sha512-XknR1To5RJbMWR92h3VCOA+DaKnjLDgKSNrWVAdbqkrnlpB1zygWFSXQQeV38f8ySkCwbt8NaUw2Mhi3Z6w+Eg==",
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.142.1",
-        "constructs": "^10.0.0"
       }
     },
     "node_modules/sst/node_modules/@aws-crypto/sha256-js": {
@@ -28336,6 +29394,694 @@
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "psa": {
+      "name": "@web3-storage/w3infra-psa",
+      "version": "0.0.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.658.1",
+        "@aws-sdk/s3-request-presigner": "^3.658.1",
+        "multiformats": "^13.3.0",
+        "sst": "^2.43.7"
+      }
+    },
+    "psa/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "psa/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "psa/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "psa/node_modules/@smithy/signature-v4": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.3.0.tgz",
+      "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "psa/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "psa/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "psa/node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "psa/node_modules/@smithy/util-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "psa/node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "psa/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "psa/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "psa/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "psa/node_modules/builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "psa/node_modules/conf": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.1",
+        "json-schema-typed": "^7.0.3",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "psa/node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "psa/node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "psa/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "psa/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "psa/node_modules/ink": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-4.4.1.tgz",
+      "integrity": "sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^6.0.0",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.2.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^3.1.0",
+        "code-excerpt": "^4.0.0",
+        "indent-string": "^5.0.0",
+        "is-ci": "^3.0.1",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lodash": "^4.17.21",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^6.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^5.1.2",
+        "type-fest": "^0.12.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.1.0",
+        "ws": "^8.12.0",
+        "yoga-wasm-web": "~0.3.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "psa/node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "psa/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
+      "license": "BSD-2-Clause"
+    },
+    "psa/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "psa/node_modules/minimatch": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
+      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "psa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/onetime/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "psa/node_modules/ora": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
+      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "psa/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "psa/node_modules/react-devtools-core": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.28.5.tgz",
+      "integrity": "sha512-cq/o30z9W2Wb4rzBefjv5fBalHU0rJGZCHAkf/RHSBWSSYwh8PlQTqqOJmgIIbBtpj27T6FIPXeomIjZtCNVqA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "psa/node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "psa/node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "psa/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "psa/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "psa/node_modules/slice-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-6.0.0.tgz",
+      "integrity": "sha512-6bn4hRfkTvDfUoEQYkERg0BVF1D0vrX9HEkMl08uDiNWvVvjylLHvZFZWkDo6wjT8tUctbYl1nCOuE66ZTaUtA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "psa/node_modules/sst": {
+      "version": "2.43.7",
+      "resolved": "https://registry.npmjs.org/sst/-/sst-2.43.7.tgz",
+      "integrity": "sha512-zst5/3KISVS0Tcx28vDNs270EJ7I1IPTXbtenMDf9BNKhcRwTYjBUAGlRrpDwDzTc4hbvqoyww6DCh5+tDX6RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-cdk/aws-lambda-python-alpha": "2.142.1-alpha.0",
+        "@aws-cdk/cloud-assembly-schema": "2.142.1",
+        "@aws-cdk/cloudformation-diff": "2.142.1",
+        "@aws-cdk/cx-api": "2.142.1",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-sdk/client-cloudformation": "^3.454.0",
+        "@aws-sdk/client-ecs": "^3.454.0",
+        "@aws-sdk/client-eventbridge": "^3.454.0",
+        "@aws-sdk/client-iam": "^3.454.0",
+        "@aws-sdk/client-iot": "^3.454.0",
+        "@aws-sdk/client-iot-data-plane": "^3.454.0",
+        "@aws-sdk/client-lambda": "^3.454.0",
+        "@aws-sdk/client-rds-data": "^3.454.0",
+        "@aws-sdk/client-s3": "^3.454.0",
+        "@aws-sdk/client-ssm": "^3.454.0",
+        "@aws-sdk/client-sts": "^3.454.0",
+        "@aws-sdk/config-resolver": "^3.374.0",
+        "@aws-sdk/credential-providers": "^3.454.0",
+        "@aws-sdk/middleware-retry": "^3.374.0",
+        "@aws-sdk/middleware-signing": "^3.451.0",
+        "@aws-sdk/signature-v4-crt": "^3.451.0",
+        "@aws-sdk/smithy-client": "^3.374.0",
+        "@babel/core": "^7.0.0-0",
+        "@babel/generator": "^7.20.5",
+        "@babel/plugin-syntax-typescript": "^7.21.4",
+        "@smithy/signature-v4": "^2.0.16",
+        "@trpc/server": "9.16.0",
+        "adm-zip": "^0.5.10",
+        "aws-cdk-lib": "2.142.1",
+        "aws-iot-device-sdk": "^2.2.13",
+        "aws-sdk": "^2.1501.0",
+        "builtin-modules": "3.2.0",
+        "cdk-assets": "2.142.1",
+        "chalk": "^5.2.0",
+        "chokidar": "^3.5.3",
+        "ci-info": "^3.7.0",
+        "colorette": "^2.0.19",
+        "conf": "^10.2.0",
+        "constructs": "10.3.0",
+        "cross-spawn": "^7.0.3",
+        "dendriform-immer-patch-optimiser": "^2.1.0",
+        "dotenv": "^16.0.3",
+        "esbuild": "0.18.13",
+        "express": "^4.18.2",
+        "fast-jwt": "^3.1.1",
+        "get-port": "^6.1.2",
+        "glob": "^10.0.0",
+        "graphql": "*",
+        "graphql-yoga": "^3.9.0",
+        "immer": "9",
+        "ink": "^4.0.0",
+        "ink-spinner": "^5.0.0",
+        "kysely": "^0.25.0",
+        "kysely-codegen": "^0.10.1",
+        "kysely-data-api": "^0.2.1",
+        "minimatch": "^6.1.6",
+        "openid-client": "^5.1.8",
+        "ora": "^6.1.2",
+        "react": "^18.0.0",
+        "remeda": "^1.3.0",
+        "sst-aws-cdk": "2.142.1",
+        "tree-kill": "^1.2.2",
+        "undici": "^5.12.0",
+        "uuid": "^9.0.0",
+        "ws": "^8.11.0",
+        "yargs": "^17.6.2",
+        "zod": "^3.21.4"
+      },
+      "bin": {
+        "sst": "cli/sst.js"
+      },
+      "peerDependencies": {
+        "@sls-next/lambda-at-edge": "^3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "@sls-next/lambda-at-edge": {
+          "optional": true
+        }
+      }
+    },
+    "psa/node_modules/type-fest": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
+      "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "replicator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7928,9 +7928,10 @@
       "dev": true
     },
     "node_modules/@ipld/car": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.3.0.tgz",
-      "integrity": "sha512-OB8LVvJeVAFFGluNIkZeDZ/aGeoekFKsuIvNT9I5sJIb5WekQuW5+lekjQ7Z7mZ7DBKuke/kI4jBT1j0/akU1w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.3.2.tgz",
+      "integrity": "sha512-Bb4XrCFlnsCb9tTzZ1I8zo9O61D9qm7HfvuYrQ9gzdE8YhjyVIjrjmHmnoSWV/uCmyc2/bcqiDPIg+9WljXNzg==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.7",
         "cborg": "^4.0.5",
@@ -14628,6 +14629,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/carstream/-/carstream-2.2.0.tgz",
       "integrity": "sha512-/gHkK0lQjmGM45fhdx8JD+x7a1XS1qUk3T9xWWSt3oZiWPLq4u/lnDstp+N55K7hqTKKlb0CCr43EHTrlbmJSQ==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.3",
         "multiformats": "^13.0.1",
@@ -17132,6 +17134,7 @@
       "resolved": "https://registry.npmjs.org/entail/-/entail-2.1.2.tgz",
       "integrity": "sha512-/icW51VHeJo5j6z6/80vO6R7zAdvHDODHYcc2jItrhRvP/zfTlm2b+xcEkp/Vt3UI6R5651Stw0AGpE1Gzkm6Q==",
       "dev": true,
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "dequal": "^2.0.3",
         "globby": "13.1.4",
@@ -29404,6 +29407,11 @@
         "@aws-sdk/s3-request-presigner": "^3.658.1",
         "multiformats": "^13.3.0",
         "sst": "^2.43.7"
+      },
+      "devDependencies": {
+        "@ipld/car": "^5.3.2",
+        "entail": "^2.1.2",
+        "nanoid": "^5.0.7"
       }
     },
     "psa/node_modules/@aws-crypto/sha256-js": {
@@ -29837,6 +29845,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "psa/node_modules/nanoid": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "psa/node_modules/onetime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25690,6 +25690,7 @@
       "resolved": "https://registry.npmjs.org/reload/-/reload-3.3.0.tgz",
       "integrity": "sha512-TObPRTy5dPlw9DS8n8ROd2BLnxI+RvVn4r0WBARVAfJ493jjcN70NI5TdkcrJmex2aQh5bfQJbFbr1NapU7Lnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cli-color": "~2.0.0",
         "commander": "~12.1.0",
@@ -30382,7 +30383,7 @@
         "esbuild": "^0.23.1",
         "express": "^4.19.2",
         "nodemon": "^3.1.4",
-        "reload": "^3.2.2",
+        "reload": "^3.3.0",
         "testcontainers": "^10.7.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "carpark",
     "filecoin",
     "indexer",
+    "psa",
     "replicator",
     "roundabout",
     "tools",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
       "unicorn/no-array-reduce": "off",
       "unicorn/no-await-expression-member": "off",
       "unicorn/no-for-loop": "off",
+      "unicorn/numeric-separators-style": "off",
       "unicorn/prefer-export-from": "off",
       "unicorn/prefer-object-from-entries": "off",
       "unicorn/prefer-set-has": "off",

--- a/psa/config.js
+++ b/psa/config.js
@@ -1,0 +1,26 @@
+import { base32 } from 'multiformats/bases/base32'
+
+/** @type {import('../lib.js').Bucket[]} */
+export const buckets = [
+  {
+    name: process.env.S3_DOTSTORAGE_0_BUCKET_NAME,
+    region: process.env.S3_DOTSTORAGE_0_BUCKET_REGION,
+    toKey: root => {
+      const s = root.toV1().toString(base32)
+      return `complete/${s}/${s}.car`
+    }
+  },
+  {
+    name: process.env.S3_DOTSTORAGE_1_BUCKET_NAME,
+    region: process.env.S3_DOTSTORAGE_1_BUCKET_REGION,
+    toKey: root => {
+      const s = root.toV1().toString(base32)
+      return `complete/${s}/${s}.car`
+    }
+  },
+  {
+    name: process.env.S3_PICKUP_BUCKET_NAME,
+    region: process.env.S3_PICKUP_BUCKET_REGION,
+    toKey: r => `pickup/${r}/${r}.root.car`
+  }
+]

--- a/psa/config.js
+++ b/psa/config.js
@@ -1,26 +1,53 @@
 import { base32 } from 'multiformats/bases/base32'
+import { S3Client } from '@aws-sdk/client-s3'
+import { createDudeWhereLocator, createHashEncodedInKeyHasher, createObjectHasher, createObjectLocator } from './lib.js'
+import { mustGetEnv } from '../lib/env.js'
 
-/** @type {import('../lib.js').Bucket[]} */
+/** @type {import('./lib.js').Bucket[]} */
 export const buckets = [
   {
-    name: process.env.S3_DOTSTORAGE_0_BUCKET_NAME,
-    region: process.env.S3_DOTSTORAGE_0_BUCKET_REGION,
-    toKey: root => {
-      const s = root.toV1().toString(base32)
-      return `complete/${s}/${s}.car`
-    }
+    locator: createObjectLocator(
+      new S3Client({ region: mustGetEnv('S3_DOTSTORAGE_0_BUCKET_REGION') }),
+      mustGetEnv('S3_DOTSTORAGE_0_BUCKET_NAME'),
+      root => {
+        const s = root.toV1().toString(base32)
+        return `complete/${s}/${s}.car`
+      } 
+    ),
+    hasher: createObjectHasher()
   },
   {
-    name: process.env.S3_DOTSTORAGE_1_BUCKET_NAME,
-    region: process.env.S3_DOTSTORAGE_1_BUCKET_REGION,
-    toKey: root => {
-      const s = root.toV1().toString(base32)
-      return `complete/${s}/${s}.car`
-    }
+    locator: createObjectLocator(
+      new S3Client({ region: mustGetEnv('S3_DOTSTORAGE_1_BUCKET_REGION') }),
+      mustGetEnv('S3_DOTSTORAGE_1_BUCKET_NAME'),
+      root => {
+        const s = root.toV1().toString(base32)
+        return `complete/${s}/${s}.car`
+      } 
+    ),
+    hasher: createObjectHasher()
   },
   {
-    name: process.env.S3_PICKUP_BUCKET_NAME,
-    region: process.env.S3_PICKUP_BUCKET_REGION,
-    toKey: r => `pickup/${r}/${r}.root.car`
+    locator: createObjectLocator(
+      new S3Client({ region: mustGetEnv('S3_PICKUP_BUCKET_REGION') }),
+      mustGetEnv('S3_PICKUP_BUCKET_NAME'),
+      r => `pickup/${r}/${r}.root.car`
+    ),
+    hasher: createObjectHasher()
+  },
+  {
+    locator: createDudeWhereLocator(
+      new S3Client({
+        endpoint: mustGetEnv('R2_ENDPOINT'),
+        credentials: {
+          accessKeyId: mustGetEnv('R2_ACCESS_KEY_ID'),
+          secretAccessKey: mustGetEnv('R2_SECRET_ACCESS_KEY'),
+        },
+        region: mustGetEnv('R2_REGION')
+      }),
+      mustGetEnv('R2_DUDEWHERE_BUCKET_NAME'),
+      mustGetEnv('R2_CARPARK_BUCKET_NAME')
+    ),
+    hasher: createHashEncodedInKeyHasher()
   }
 ]

--- a/psa/functions/download.js
+++ b/psa/functions/download.js
@@ -1,22 +1,23 @@
 import { ApiHandler } from 'sst/node/api'
 import * as Link from 'multiformats/link'
 import { getDownloadURL, NotFound } from '../lib.js'
-import { errorResponse } from './lib/util.js'
+import * as Config from '../config.js'
+import { errorResponse, okResponse } from '../util.js'
 
 export const handler = ApiHandler(async event => {
   const { searchParams } = new URL(`http://localhost/?${event.rawQueryString}`)
 
   let root
   try {
-    root = Link.parse(searchParams.get('root'))
-  } catch (err) {
+    root = Link.parse(searchParams.get('root') ?? '')
+  } catch {
     return errorResponse('Invalid "root" search parameter', 400)
   }
 
   try {
-    const url = await getDownloadURL(buckets, root)
+    const url = await getDownloadURL(Config.buckets, root)
     return okResponse({ root, url })
-  } catch (err) {
+  } catch (/** @type {any} */ err) {
     return errorResponse(err.message, err instanceof NotFound ? 404 : 500)
   }
 })

--- a/psa/functions/download.js
+++ b/psa/functions/download.js
@@ -1,0 +1,22 @@
+import { ApiHandler } from 'sst/node/api'
+import * as Link from 'multiformats/link'
+import { getDownloadURL, NotFound } from '../lib.js'
+import { errorResponse } from './lib/util.js'
+
+export const handler = ApiHandler(async event => {
+  const { searchParams } = new URL(`http://localhost/?${event.rawQueryString}`)
+
+  let root
+  try {
+    root = Link.parse(searchParams.get('root'))
+  } catch (err) {
+    return errorResponse('Invalid "root" search parameter', 400)
+  }
+
+  try {
+    const url = await getDownloadURL(buckets, root)
+    return okResponse({ root, url })
+  } catch (err) {
+    return errorResponse(err.message, err instanceof NotFound ? 404 : 500)
+  }
+})

--- a/psa/functions/hash.js
+++ b/psa/functions/hash.js
@@ -15,8 +15,8 @@ export const handler = ApiHandler(async event => {
   }
 
   try {
-    const shard = await getHash(Config.buckets, root)
-    return okResponse({ root, shard })
+    const { link, size } = await getHash(Config.buckets, root)
+    return okResponse({ root, link, size })
   } catch (err) {
     return errorResponse(err.message, err instanceof NotFound ? 404 : 500)
   }

--- a/psa/functions/hash.js
+++ b/psa/functions/hash.js
@@ -1,0 +1,23 @@
+import { ApiHandler } from 'sst/node/api'
+import * as Link from 'multiformats/link'
+import { getHash, NotFound } from '../lib.js'
+import * as Config from '../config.js'
+import { okResponse, errorResponse } from '../util.js'
+
+export const handler = ApiHandler(async event => {
+  const { searchParams } = new URL(`http://localhost/?${event.rawQueryString}`)
+
+  let root
+  try {
+    root = Link.parse(searchParams.get('root'))
+  } catch (err) {
+    return errorResponse('Invalid "root" search parameter', 400)
+  }
+
+  try {
+    const shard = await getHash(Config.buckets, root)
+    return okResponse({ root, shard })
+  } catch (err) {
+    return errorResponse(err.message, err instanceof NotFound ? 404 : 500)
+  }
+})

--- a/psa/functions/hash.js
+++ b/psa/functions/hash.js
@@ -9,15 +9,15 @@ export const handler = ApiHandler(async event => {
 
   let root
   try {
-    root = Link.parse(searchParams.get('root'))
-  } catch (err) {
+    root = Link.parse(searchParams.get('root') ?? '')
+  } catch {
     return errorResponse('Invalid "root" search parameter', 400)
   }
 
   try {
     const { link, size } = await getHash(Config.buckets, root)
     return okResponse({ root, link, size })
-  } catch (err) {
+  } catch (/** @type {any} */ err) {
     return errorResponse(err.message, err instanceof NotFound ? 404 : 500)
   }
 })

--- a/psa/lib.js
+++ b/psa/lib.js
@@ -1,11 +1,12 @@
 import crypto from 'node:crypto'
-import { HeadObjectCommand, GetObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
+import { HeadObjectCommand, GetObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import * as Link from 'multiformats/link'
 import * as Digest from 'multiformats/hashes/digest'
 import { sha256 } from 'multiformats/hashes/sha2'
 
 /**
+ * @typedef {import('@aws-sdk/client-s3').S3Client} S3Client
  * @typedef {import('multiformats').UnknownLink} UnknownLink
  * @typedef {{ locator: Locator, hasher: Hasher }} Bucket
  * @typedef {{ root: UnknownLink, client: S3Client, bucket: string, key: string, size: number }} Location
@@ -129,6 +130,7 @@ class DudeWhereLocator {
 
 /**
  * A hasher that reads data from a location and hashes it.
+ *
  * @returns {Hasher}
  */
 export const createObjectHasher = () => new ObjectHasher()
@@ -155,6 +157,7 @@ class ObjectHasher {
 
 /**
  * A hasher that extracts the CAR hash from the key.
+ *
  * @returns {Hasher}
  */
 export const createHashEncodedInKeyHasher = () => new HashEncodedInKeyHasher()
@@ -179,7 +182,7 @@ export const DownloadURLExpiration = 1000 * 60 * 60 * 24 // 1 day in seconds
 /**
  * Get a signed download URL for the CAR file stored in one of the passed
  * buckets that contains the complete DAG for the given root CID.
- * 
+ *
  * @param {Bucket[]} buckets
  * @param {UnknownLink} root
  * @throws {NotFound}

--- a/psa/lib.js
+++ b/psa/lib.js
@@ -1,0 +1,92 @@
+import crypto from 'node:crypto'
+import { HeadObjectCommand, GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import * as Link from 'multiformats/link'
+import * as Digest from 'multiformats/hashes/digest'
+import { sha256 } from 'multiformats/hashes/sha2'
+
+/**
+ * @typedef {import('multiformats').UnknownLink} UnknownLink
+ * @typedef {{ name: string, region: string, toKey: (root: UnknownLink) => string }} Bucket
+ * @typedef {{ name: string, region: string, key: string, size: number }} Location
+ */
+
+/**
+ * @param {Bucket[]} buckets
+ * @param {UnknownLink} root
+ * @returns {Promise<Location|undefined>}
+ */
+export const locateCAR = async (buckets, root) => {
+  for (const bucket of buckets) {
+    const key = bucket.toKey(root)
+    const client = new S3Client({ region: bucket.region })
+    const cmd = new HeadObjectCommand({
+      Bucket: bucket.name,
+      Key: key
+    })
+    try {
+      const res = await client.send(cmd)
+      const size = res.ContentLength
+      if (size == null) throw new Error(`missing ContentLength: ${root}`)
+      return { name: bucket.name, region: bucket.region, key, size }
+    } catch (err) {
+      if (err?.$metadata.httpStatusCode !== 404) {
+        throw err
+      }
+    }
+  }
+}
+
+/**
+ * Get the hash of a CAR file stored in one of the passed buckets that contains
+ * the complete DAG for the given root CID.
+ * 
+ * @param {Bucket[]} buckets
+ * @param {UnknownLink} root
+ * @throws {NotFound}
+ */
+export const getHash = async (buckets, root) => {
+  const bucket = await locateCAR(buckets, root)
+  if (!bucket) {
+    throw new NotFound(`Not found: ${root}`)
+  }
+
+  const s3 = new S3Client({ region })
+  const cmd = new GetObjectCommand({ Bucket: bucket.name, Key: bucket.key })
+
+  const res = await s3.send(cmd)
+  if (!res.Body) {
+    throw new NotFound(`Object not found: ${root}`)
+  }
+
+  const hash = crypto.createHash('sha256')
+  await res.Body.transformToWebStream()
+    .pipeTo(new WritableStream({ write: chunk => { hash.update(chunk) } }))
+
+  const digest = Digest.create(sha256.code, hash.digest())
+  return Link.create(CAR_CODEC, digest)
+}
+
+export const DownloadURLExpiration = 1000 * 60 * 60 * 24 // 1 day in seconds
+
+/**
+ * Get a signed download URL for the CAR file stored in one of the passed
+ * buckets that contains the complete DAG for the given root CID.
+ * 
+ * @param {Bucket[]} buckets
+ * @param {UnknownLink} root
+ * @throws {NotFound}
+ */
+export const getDownloadURL = async (buckets, root) => {
+  const bucket = await locateCAR(buckets, root)
+  if (!bucket) {
+    throw new NotFound(`Not found: ${root}`)
+  }
+
+  const s3 = new S3Client({ region: bucket.region })
+  const cmd = new GetObjectCommand({ Bucket: bucket.name, Key: bucket.key })
+  const url = await getSignedUrl(s3, cmd, { expiresIn: DownloadURLExpiration })
+  return new URL(url)
+}
+
+export class NotFound extends Error {}

--- a/psa/lib.js
+++ b/psa/lib.js
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { HeadObjectCommand, GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { HeadObjectCommand, GetObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import * as Link from 'multiformats/link'
 import * as Digest from 'multiformats/hashes/digest'
@@ -7,35 +7,13 @@ import { sha256 } from 'multiformats/hashes/sha2'
 
 /**
  * @typedef {import('multiformats').UnknownLink} UnknownLink
- * @typedef {{ name: string, region: string, toKey: (root: UnknownLink) => string }} Bucket
- * @typedef {{ bucket: Bucket, key: string, size: number }} Location
+ * @typedef {{ locator: Locator, hasher: Hasher }} Bucket
+ * @typedef {{ root: UnknownLink, client: S3Client, bucket: string, key: string, size: number }} Location
+ * @typedef {{ locate: (root: UnknownLink) => Promise<Location|undefined> }} Locator
+ * @typedef {{ digest: (location: Location) => Promise<import('multiformats').Link> }} Hasher
  */
 
-/**
- * @param {Bucket[]} buckets
- * @param {UnknownLink} root
- * @returns {Promise<Location|undefined>}
- */
-export const locateCAR = async (buckets, root) => {
-  for (const bucket of buckets) {
-    const key = bucket.toKey(root)
-    const client = new S3Client({ region: bucket.region })
-    const cmd = new HeadObjectCommand({
-      Bucket: bucket.name,
-      Key: key
-    })
-    try {
-      const res = await client.send(cmd)
-      const size = res.ContentLength
-      if (size == null) throw new Error(`missing ContentLength: ${root}`)
-      return { bucket, key, size }
-    } catch (err) {
-      if (err?.$metadata.httpStatusCode !== 404) {
-        throw err
-      }
-    }
-  }
-}
+const CAR_CODEC = 0x0202
 
 /**
  * Get the hash of a CAR file stored in one of the passed buckets that contains
@@ -46,25 +24,154 @@ export const locateCAR = async (buckets, root) => {
  * @throws {NotFound}
  */
 export const getHash = async (buckets, root) => {
-  const location = await locateCAR(buckets, root)
-  if (!location) {
-    throw new NotFound(`Not found: ${root}`)
+  for (const bucket of buckets) {
+    const location = await bucket.locator.locate(root)
+    if (!location) continue
+
+    const link = await bucket.hasher.digest(location)
+    return { link, size: location.size }
+  }
+  throw new NotFound(`not found: ${root}`)
+}
+
+/**
+ * Create a locator that can find a key in any S3 compatible bucket.
+ *
+ * @param {S3Client} client 
+ * @param {string} bucketName 
+ * @param {(root: UnknownLink) => string} encodeKey
+ * @returns {Locator}
+ */
+export const createObjectLocator = (client, bucketName, encodeKey) =>
+  new S3ObjectLocator(client, bucketName, encodeKey)
+
+/** @implements {Locator} */
+class S3ObjectLocator {
+  /**
+   * @param {S3Client} client 
+   * @param {string} bucketName 
+   * @param {(root: UnknownLink) => string} encodeKey 
+   */
+  constructor (client, bucketName, encodeKey) {
+    this.client = client
+    this.bucketName = bucketName
+    this.encodeKey = encodeKey
   }
 
-  const s3 = new S3Client({ region })
-  const cmd = new GetObjectCommand({ Bucket: location.bucket.name, Key: location.key })
+  /** @param {UnknownLink} root */
+  async locate (root) {
+    const key = this.encodeKey(root)
+    const cmd = new HeadObjectCommand({ Bucket: this.bucketName, Key: key })
+    try {
+      const res = await this.client.send(cmd)
+      const size = res.ContentLength
+      if (size == null) throw new Error(`missing ContentLength: ${root}`)
+      return { root, client: this.client, bucket: this.bucketName, key, size }
+    } catch (/** @type {any} */ err) {
+      if (err?.$metadata.httpStatusCode !== 404) {
+        throw err
+      }
+    }
+  }
+}
 
-  const res = await s3.send(cmd)
-  if (!res.Body) {
-    throw new NotFound(`Object not found: ${root}`)
+/**
+ * Creates a client that knows how to locate an object by looking in the legacy
+ * DUDEWHERE index bucket to find the key.
+ *
+ * @param {S3Client} client 
+ * @param {string} indexBucketName Name of the DUDEWHERE bucket.
+ * @param {string} dataBucketName Name of the CARPARK bucket.
+ */
+export const createDudeWhereLocator = (client, indexBucketName, dataBucketName) =>
+  new DudeWhereLocator(client, indexBucketName, dataBucketName)
+
+/** @implements {Locator} */
+class DudeWhereLocator {
+  /**
+   * @param {S3Client} client
+   * @param {string} indexBucketName Name of the DUDEWHERE bucket.
+   * @param {string} dataBucketName Name of the CARPARK bucket.
+   */
+  constructor (client, indexBucketName, dataBucketName) {
+    this.client = client
+    this.indexBucketName = indexBucketName
+    this.dataBucketName = dataBucketName
   }
 
-  const hash = crypto.createHash('sha256')
-  await res.Body.transformToWebStream()
-    .pipeTo(new WritableStream({ write: chunk => { hash.update(chunk) } }))
+  /** @param {UnknownLink} root */
+  async locate (root) {
+    const cmd = new ListObjectsV2Command({
+      Bucket: this.indexBucketName,
+      MaxKeys: 2,
+      Prefix: `${root}/`
+    })
+    const res = await this.client.send(cmd)
+    const contents = res.Contents
 
-  const digest = Digest.create(sha256.code, hash.digest())
-  return { link: Link.create(CAR_CODEC, digest), size: location.size }
+    // if there's no items then it simply not found
+    if (!contents?.length) return
+    // if there's more than one item, then someone else has stored this root,
+    // as multiple shards, or with a different block ordering. There's no way
+    // to know which subset of shards contains the entire DAG.
+    if (contents.length > 1) return
+    // if no key then this is a weird situation
+    if (!contents[0].Key) return
+
+    const key = contents[0].Key
+    const locator = createObjectLocator(this.client, this.dataBucketName, () => {
+      const link = Link.parse(key.split('/').pop() ?? '')
+      return `${link}/${link}.car`
+    })
+    return locator.locate(root)
+  }
+}
+
+/**
+ * A hasher that reads data from a location and hashes it.
+ * @returns {Hasher}
+ */
+export const createObjectHasher = () => new ObjectHasher()
+
+/** @implements {Hasher} */
+class ObjectHasher {
+  /** @param {Location} location */
+  async digest (location) {
+    const cmd = new GetObjectCommand({ Bucket: location.bucket, Key: location.key })
+
+    const res = await location.client.send(cmd)
+    if (!res.Body) {
+      throw new NotFound(`Object not found: ${location.root}`) // shouldn't happen
+    }
+
+    const hash = crypto.createHash('sha256')
+    await res.Body.transformToWebStream()
+      .pipeTo(new WritableStream({ write: chunk => { hash.update(chunk) } }))
+
+    const digest = Digest.create(sha256.code, hash.digest())
+    return Link.create(CAR_CODEC, digest)
+  }
+}
+
+/**
+ * A hasher that extracts the CAR hash from the key.
+ * @returns {Hasher}
+ */
+export const createHashEncodedInKeyHasher = () => new HashEncodedInKeyHasher()
+
+/** @implements {Hasher} */
+class HashEncodedInKeyHasher {
+  /** @param {Location} location */
+  async digest (location) {
+    const filename = location.key.split('/').pop()
+    if (!filename || !filename.endsWith('.car')) {
+      throw new Error('unexpected key format')
+    }
+    const hash =
+      /** @type {import('multiformats').Link<unknown, number, number, 1>} */ 
+      (Link.parse(filename.replace('.car', '')))
+    return hash
+  }
 }
 
 export const DownloadURLExpiration = 1000 * 60 * 60 * 24 // 1 day in seconds
@@ -78,15 +185,15 @@ export const DownloadURLExpiration = 1000 * 60 * 60 * 24 // 1 day in seconds
  * @throws {NotFound}
  */
 export const getDownloadURL = async (buckets, root) => {
-  const location = await locateCAR(buckets, root)
-  if (!location) {
-    throw new NotFound(`Not found: ${root}`)
-  }
+  for (const bucket of buckets) {
+    const location = await bucket.locator.locate(root)
+    if (!location) continue
 
-  const s3 = new S3Client({ region: location.bucket.region })
-  const cmd = new GetObjectCommand({ Bucket: location.bucket.name, Key: location.key })
-  const url = await getSignedUrl(s3, cmd, { expiresIn: DownloadURLExpiration })
-  return new URL(url)
+    const cmd = new GetObjectCommand({ Bucket: location.bucket, Key: location.key })
+    const url = await getSignedUrl(location.client, cmd, { expiresIn: DownloadURLExpiration })
+    return new URL(url)
+  }
+  throw new NotFound(`not found: ${root}`)
 }
 
 export class NotFound extends Error {}

--- a/psa/package.json
+++ b/psa/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@web3-storage/w3infra-psa",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "echo 'TODO'"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.658.1",
+    "@aws-sdk/s3-request-presigner": "^3.658.1",
+    "multiformats": "^13.3.0",
+    "sst": "^2.43.7"
+  }
+}

--- a/psa/package.json
+++ b/psa/package.json
@@ -3,12 +3,17 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "test": "echo 'TODO'"
+    "test": "entail test/*.spec.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.658.1",
     "@aws-sdk/s3-request-presigner": "^3.658.1",
     "multiformats": "^13.3.0",
     "sst": "^2.43.7"
+  },
+  "devDependencies": {
+    "@ipld/car": "^5.3.2",
+    "entail": "^2.1.2",
+    "nanoid": "^5.0.7"
   }
 }

--- a/psa/test/helpers/bytes.js
+++ b/psa/test/helpers/bytes.js
@@ -1,0 +1,14 @@
+import { webcrypto } from 'node:crypto'
+
+/** @param {number} size */
+export const randomBytes = size => {
+  const bytes = new Uint8Array(size)
+  while (size) {
+    const chunk = new Uint8Array(Math.min(size, 65_536))
+    webcrypto.getRandomValues(chunk)
+
+    size -= bytes.length
+    bytes.set(chunk, size)
+  }
+  return bytes
+}

--- a/psa/test/helpers/dag.js
+++ b/psa/test/helpers/dag.js
@@ -1,0 +1,39 @@
+import { sha256 } from 'multiformats/hashes/sha2'
+import * as raw from 'multiformats/codecs/raw'
+import * as Link from 'multiformats/link'
+import { CarBufferWriter } from '@ipld/car'
+import { randomInteger } from './math.js'
+import { randomBytes } from './bytes.js'
+
+export const randomBlock = () => {
+  const bytes = randomBytes(randomInteger(1, 1024 * 1024))
+  const mh = sha256.digest(bytes)
+  if (mh instanceof Promise) throw new Error('sha256 hasher is async')
+  return { cid: Link.create(raw.code, mh), bytes }
+}
+
+/**
+ * @param {import('multiformats').UnknownLink} root
+ * @param {import('multiformats').Block[]} blocks
+ */
+export const encodeCAR = (root, blocks) => {
+  const roots = [root]
+  // @ts-expect-error
+  const headerSize = CarBufferWriter.headerLength({ roots })
+  let blocksSize = 0
+  for (const b of blocks) {
+    // @ts-expect-error
+    blocksSize += CarBufferWriter.blockLength(b)
+  }
+  // @ts-expect-error
+  const writer = CarBufferWriter.createWriter(new Uint8Array(headerSize + blocksSize), { roots })
+
+  for (const b of blocks) {
+    // @ts-expect-error
+    writer.write(b)
+  }
+  const bytes = writer.close()
+  const mh = sha256.digest(bytes)
+  if (mh instanceof Promise) throw new Error('sha256 hasher is async')
+  return { cid: Link.create(0x0202, mh), bytes }
+}

--- a/psa/test/helpers/math.js
+++ b/psa/test/helpers/math.js
@@ -1,0 +1,9 @@
+/**
+ * @param {number} min 
+ * @param {number} max 
+ */
+export const randomInteger = (min, max) => {
+  min = Math.ceil(min)
+  max = Math.floor(max)
+  return Math.floor(Math.random() * (max - min) + min)
+}

--- a/psa/test/helpers/resources.js
+++ b/psa/test/helpers/resources.js
@@ -1,0 +1,35 @@
+import { GenericContainer as Container } from 'testcontainers'
+import { CreateBucketCommand, S3Client } from '@aws-sdk/client-s3'
+import { customAlphabet } from 'nanoid'
+
+const id = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10)
+
+/** @param {{ region?: string }} [opts] */
+export const createS3 = async opts => {
+  console.log('Creating local S3...')
+  const port = 9000
+  const region = opts?.region ?? 'us-west-2'
+  const container = await new Container('quay.io/minio/minio')
+    .withCommand(['server', '/data'])
+    .withExposedPorts(port)
+    .start()
+  const endpoint = `http://${container.getHost()}:${container.getMappedPort(port)}`
+  const clientOpts = {
+    endpoint,
+    forcePathStyle: true,
+    region,
+    credentials: {
+      accessKeyId: 'minioadmin',
+      secretAccessKey: 'minioadmin',
+    }
+  }
+  return { client: new S3Client(clientOpts), endpoint }
+}
+
+/** @param {S3Client} s3 */
+export async function createBucket(s3) {
+  const name = id()
+  console.log(`Creating S3 bucket "${name}"...`)
+  await s3.send(new CreateBucketCommand({ Bucket: name }))
+  return name
+}

--- a/psa/test/lib.spec.js
+++ b/psa/test/lib.spec.js
@@ -1,0 +1,113 @@
+import { PutObjectCommand } from '@aws-sdk/client-s3'
+import { createDudeWhereLocator, createHashEncodedInKeyHasher, createObjectHasher, createObjectLocator } from '../lib.js'
+import { encodeCAR, randomBlock } from './helpers/dag.js'
+import { createBucket, createS3 } from './helpers/resources.js'
+
+const s3 = await createS3()
+
+export const testObjectLocator = {
+  'should find object': async (/** @type {import('entail').assert} */ assert) => {
+    const bucket = await createBucket(s3.client)
+    const block = randomBlock()
+    const car = encodeCAR(block.cid, [block])
+    const key = `complete/${block.cid}.car`
+
+    await s3.client.send(new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: car.bytes
+    }))
+
+    const locator = createObjectLocator(s3.client, bucket, r => `complete/${r}.car`)
+    const location = await locator.locate(block.cid)
+
+    assert.ok(location)
+    assert.equal(location.bucket, bucket)
+    assert.equal(location.key, key)
+    assert.equal(location.size, car.bytes.length)
+  }
+}
+
+export const testDudeWhereLocator = {
+  'should find object': async (/** @type {import('entail').assert} */ assert) => {
+    const [indexBucket, dataBucket] = await Promise.all([
+      createBucket(s3.client),
+      createBucket(s3.client)
+    ])
+    const block = randomBlock()
+    const car = encodeCAR(block.cid, [block])
+    const indexKey = `${block.cid}/${car.cid}`
+    const dataKey = `${car.cid}/${car.cid}.car`
+
+    await Promise.all([
+      s3.client.send(new PutObjectCommand({
+        Bucket: indexBucket,
+        Key: indexKey,
+        Body: new Uint8Array()
+      })),
+      s3.client.send(new PutObjectCommand({
+        Bucket: dataBucket,
+        Key: dataKey,
+        Body: car.bytes
+      }))
+    ])
+
+    const locator = createDudeWhereLocator(s3.client, indexBucket, dataBucket)
+    const location = await locator.locate(block.cid)
+
+    assert.ok(location)
+    assert.equal(location.bucket, dataBucket)
+    assert.equal(location.key, dataKey)
+    assert.equal(location.size, car.bytes.length)
+  }
+}
+
+export const testObjectHasher = {
+  'should hash object': async (/** @type {import('entail').assert} */ assert) => {
+    const bucket = await createBucket(s3.client)
+    const block = randomBlock()
+    const car = encodeCAR(block.cid, [block])
+    const key = `complete/${block.cid}.car`
+
+    await s3.client.send(new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: car.bytes
+    }))
+
+    const hasher = createObjectHasher()
+    const link = await hasher.digest({
+      client: s3.client,
+      root: block.cid,
+      bucket,
+      key,
+      size: car.bytes.length
+    })
+    assert.equal(link.toString(), car.cid.toString())
+  }
+}
+
+export const testHashEncodedInKeyHasher = {
+  'should hash object': async (/** @type {import('entail').assert} */ assert) => {
+    const bucket = await createBucket(s3.client)
+    const block = randomBlock()
+    const car = encodeCAR(block.cid, [block])
+    const key = `${car.cid}/${car.cid}.car`
+
+    await s3.client.send(new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: new Uint8Array() // purposely incorrect to ensure hash is coming from key
+    }))
+
+    const hasher = createHashEncodedInKeyHasher()
+    const link = await hasher.digest({
+      client: s3.client,
+      root: block.cid,
+      bucket,
+      key,
+      size: car.bytes.length
+    })
+    assert.equal(link.toString(), car.cid.toString())
+  }
+}

--- a/psa/util.js
+++ b/psa/util.js
@@ -7,7 +7,10 @@ export const okResponse = (value) => ({
   body: JSON.stringify({ ok: value })
 })
 
-/** @param {string} message */
+/**
+ * @param {string} message
+ * @param {number} [statusCode]
+ */
 export const errorResponse = (message, statusCode = 500) => ({
   statusCode,
   body: JSON.stringify({ error: { message } })

--- a/psa/util.js
+++ b/psa/util.js
@@ -1,0 +1,14 @@
+/**
+ * @template T
+ * @param {T} value
+ */
+export const okResponse = (value) => ({
+  statusCode: 200,
+  body: JSON.stringify({ ok: value })
+})
+
+/** @param {string} message */
+export const errorResponse = (message, statusCode = 500) => ({
+  statusCode,
+  body: JSON.stringify({ error: { message } })
+})

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -13,6 +13,7 @@ import { ReplicatorStack } from './stacks/replicator-stack.js'
 import { UcanFirehoseStack } from './stacks/firehose-stack.js'
 import { IndexerStack } from './stacks/indexer-stack.js'
 import { RoundaboutStack } from './stacks/roundabout-stack.js'
+import { PSAStack } from './stacks/psa-stack.js'
 import { isPrBuild } from './stacks/config.js'
 
 export default {
@@ -42,6 +43,7 @@ export default {
         : 'disabled'
     })
 
+    app.stack(PSAStack)
     app.stack(BusStack)
     app.stack(UploadDbStack)
     app.stack(RoundaboutStack)

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -1,9 +1,14 @@
-/** @import { ApiDomainProps, App, Stack } from 'sst/constructs' */
 import { Duration, RemovalPolicy } from 'aws-cdk-lib'
 import { createRequire } from 'module'
 import { StartingPosition } from 'aws-cdk-lib/aws-lambda'
 import git from 'git-rev-sync'
 import { mustGetEnv } from '../lib/env.js'
+
+/**
+ * @typedef {import('sst/constructs').ApiDomainProps} ApiDomainProps
+ * @typedef {import('sst/constructs').App} App
+ * @typedef {import('sst/constructs').Stack} Stack
+ */
 
 /**
  * Get nicer bucket names

--- a/stacks/psa-stack.js
+++ b/stacks/psa-stack.js
@@ -1,0 +1,34 @@
+/**
+ * Temporary stack for the old Pinning Service API (PSA) that maps root CIDs
+ * to CAR files the complete DAGs are stored in.
+ */
+import { Function } from 'sst/constructs'
+
+/** @param {import('sst/constructs').StackContext} context */
+export function PSAStack ({ stack }) {
+  stack.setDefaultFunctionProps({
+    runtime: 'nodejs20.x',
+    architecture: 'arm_64'
+  })
+
+  const hashFunction = new Function(stack, 'hash', {
+    handler: 'shardutil/functions/hash.handler',
+    url: { cors: true, authorizer: 'none' },
+    memorySize: '4 GB',
+    timeout: '15 minutes'
+  })
+
+  hashFunction.attachPermissions(['s3:GetObject'])
+
+  const downloadFunction = new Function(stack, 'download', {
+    handler: 'shardutil/functions/download.handler',
+    url: { cors: true, authorizer: 'none' }
+  })
+
+  downloadFunction.attachPermissions(['s3:GetObject'])
+
+  stack.addOutputs({
+    hashFunctionURL: hashFunction.url,
+    downloadFunctionURL: downloadFunction.url,
+  })
+}

--- a/stacks/psa-stack.js
+++ b/stacks/psa-stack.js
@@ -8,24 +8,32 @@ import { Function } from 'sst/constructs'
 export function PSAStack ({ stack }) {
   stack.setDefaultFunctionProps({
     runtime: 'nodejs20.x',
-    architecture: 'arm_64'
+    architecture: 'arm_64',
+    environment: {
+      R2_ENDPOINT: process.env.R2_ENDPOINT ?? '',
+      R2_REGION: process.env.R2_REGION ?? '',
+      R2_CARPARK_BUCKET_NAME: process.env.R2_CARPARK_BUCKET_NAME ?? '',
+      R2_DUDEWHERE_BUCKET_NAME: process.env.R2_DUDEWHERE_BUCKET_NAME ?? '',
+      R2_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID ?? '',
+      R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY ?? ''
+    }
   })
 
   const hashFunction = new Function(stack, 'hash', {
-    handler: 'shardutil/functions/hash.handler',
+    handler: 'psa/functions/hash.handler',
     url: { cors: true, authorizer: 'none' },
     memorySize: '4 GB',
     timeout: '15 minutes'
   })
 
-  hashFunction.attachPermissions(['s3:GetObject'])
+  hashFunction.attachPermissions(['s3:HeadObject', 's3:GetObject'])
 
   const downloadFunction = new Function(stack, 'download', {
-    handler: 'shardutil/functions/download.handler',
+    handler: 'psa/functions/download.handler',
     url: { cors: true, authorizer: 'none' }
   })
 
-  downloadFunction.attachPermissions(['s3:GetObject'])
+  downloadFunction.attachPermissions(['s3:HeadObject', 's3:GetObject'])
 
   stack.addOutputs({
     hashFunctionURL: hashFunction.url,

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -240,7 +240,7 @@ export function UploadApiStack({ stack, app }) {
   stack.addOutputs({
     ApiEndpoints: JSON.stringify(apis.map(api => api.url)),
     CustomDomains: customDomains
-      ? JSON.stringify(customDomains.map(customDomain => `https://${customDomain.domainName}`))
+      ? JSON.stringify(customDomains.map(customDomain => `https://${customDomain?.domainName}`))
       : 'Set HOSTED_ZONES in env to deploy to a custom domain',
   })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,7 +45,8 @@
     "ucan-invocation",
     "filecoin",
     "tools",
-    "lib"
+    "lib",
+    "psa"
   ],
   "exclude": ["billing/coverage", "upload-api/dist"]
 }

--- a/upload-api/buckets/car-store.js
+++ b/upload-api/buckets/car-store.js
@@ -8,7 +8,7 @@ import { getS3Client } from '../../lib/aws/s3.js'
  *
  * @param {string} region
  * @param {string} bucketName
- * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
+ * @param {Partial<import('../../lib/aws/s3.js').Address>} [options]
  */
 export function createCarStore(region, bucketName, options) {
   const s3 = getS3Client({

--- a/upload-api/package.json
+++ b/upload-api/package.json
@@ -54,7 +54,7 @@
     "esbuild": "^0.23.1",
     "express": "^4.19.2",
     "nodemon": "^3.1.4",
-    "reload": "^3.2.2",
+    "reload": "^3.3.0",
     "testcontainers": "^10.7.1"
   },
   "ava": {

--- a/upload-api/stores/blobs.js
+++ b/upload-api/stores/blobs.js
@@ -35,7 +35,7 @@ const contentKey = (digest) => {
  *
  * @param {string} region
  * @param {string} bucketName
- * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
+ * @param {Partial<import('../../lib/aws/s3.js').Address>} [options]
  */
 export function createBlobsStorage(region, bucketName, options) {
   const s3 = getS3Client({


### PR DESCRIPTION
Adds a temporary stack for the old Pinning Service API (PSA) data.

The stack creates 2 functions:

- `hash` given a root CID, find a CAR file in one of the configured buckets and calculate it's hash.
- `download` given a root CID, find a CAR file in one of the configured buckets and return a signed URL allowing temporary access to the data.

This is for the PSA migration tool in console.

1. Users list pinned root CIDs.
2. Users get hash of CAR file containing pinned data by calling `hash`.
3. Users `blob/add` CAR file.
4. (Maybe) users need to upload the CAR, so they call `download` to get a signed URL and then download the data, and upload it to Storacha.