### PR TITLE
fix: re-add preact import

### DIFF
--- a/upload-api/html-w3s/index.jsx
+++ b/upload-api/html-w3s/index.jsx
@@ -1,4 +1,5 @@
 // @jsxImportSource preact
+import * as preact from 'preact'
 import { render } from 'preact-render-to-string'
 import { Response } from '@web-std/fetch'
 


### PR DESCRIPTION
Looks like this was removed here https://github.com/storacha/w3infra/pull/417/files#diff-fe7ebd5c64b7ab6a78e2a72d2c708860905cc2b4591b564ebe7e5d1b4a7d5d4cL5 - not sure why linting didn't pick this up.

Fixes:

```
ReferenceError: preact is not defined
  File "/var/task/upload-api/functions/validate-email.mjs", line 111928, col 7, in Object.ValidateEmail
    preact.createElement("stripe-pricing-table", {
  File "/var/task/upload-api/functions/validate-email.mjs", line 111380, col 52, in j
    U2.__d = false, b15 && b15(t15), P5 = Z2.call(U2, F7, M4);
  File "/var/task/upload-api/functions/validate-email.mjs", line 111313, col 15, in S
    var s16 = j15(n16, o16 || E6, false, void 0, c16, false, i17);
  File "/var/task/upload-api/functions/validate-email.mjs", line 111865, col 39, in new HtmlResponse
    const stringBody = buildDocument2(P4(body));
  File "/var/task/upload-api/functions/validate-email.mjs", line 112970, col 5, in validateEmailPost
    new html.HtmlResponse(
  File "node:internal/process/task_queues", line 95, col 5, in process.processTicksAndRejections
  File "/var/task/upload-api/functions/validate-email.mjs", line 75415, col 14, in processResult
    rv = await asyncHandler(event, context);
```