### PR TITLE
fix: consumerTable.get returns customer

### DIFF
--- a/billing/data/consumer.js
+++ b/billing/data/consumer.js
@@ -9,13 +9,14 @@ import { DecodeFailure, EncodeFailure, Schema } from './lib.js'
  * @typedef {import('../types').InferStoreRecord<ConsumerKey>} ConsumerKeyStoreRecord
  * @typedef {import('../lib/api').ConsumerListKey} ConsumerListKey
  * @typedef {import('../types').InferStoreRecord<ConsumerListKey>} ConsumerListKeyStoreRecord
- * @typedef {Pick<Consumer, 'consumer'|'provider'|'subscription'>} ConsumerList
+ * @typedef {Pick<Consumer, 'consumer'|'provider'|'subscription'|'customer'>} ConsumerList
  */
 
 const schema = Schema.struct({
   consumer: Schema.did(),
   provider: Schema.did({ method: 'web' }),
   subscription: Schema.text(),
+  customer: Schema.did({ method: 'mailto' }),
   cause: Schema.link({ version: 1 }).optional(),
   insertedAt: Schema.date(),
   updatedAt: Schema.date().optional()
@@ -32,6 +33,7 @@ export const encode = input => {
         consumer: input.consumer,
         provider: input.provider,
         subscription: input.subscription,
+        customer: input.customer,
         cause: input.cause ? input.cause.toString() : undefined,
         insertedAt: input.insertedAt.toISOString(),
         updatedAt: input.updatedAt ? input.updatedAt.toISOString() : undefined
@@ -52,6 +54,7 @@ export const decode = input => {
         consumer: Schema.did().from(input.consumer),
         provider: Schema.did({ method: 'web' }).from(input.provider),
         subscription: /** @type {string} */ (input.subscription),
+        customer: Schema.did({ method: 'mailto' }).from(input.customer),
         cause: input.cause ? Link.parse(/** @type {string} */ (input.cause)) : undefined,
         insertedAt: new Date(input.insertedAt),
         updatedAt: input.updatedAt ? new Date(input.updatedAt) : undefined
@@ -83,7 +86,8 @@ export const lister = {
         ok: {
           consumer: Schema.did().from(input.consumer),
           provider: Schema.did({ method: 'web' }).from(input.provider),
-          subscription: String(input.subscription)
+          subscription: String(input.subscription),
+          customer: Schema.did({ method: 'mailto' }).from(input.customer)
         }
       }
     } catch (/** @type {any} */ err) {

--- a/billing/lib/api.ts
+++ b/billing/lib/api.ts
@@ -210,6 +210,7 @@ export interface Consumer {
   consumer: ConsumerDID
   provider: ProviderDID
   subscription: string
+  customer: CustomerDID
   /** This became a required field after 2023-07-10T23:12:38.000Z. */
   cause?: Link
   insertedAt: Date
@@ -221,7 +222,7 @@ export interface ConsumerListKey { consumer: ConsumerDID }
 
 export type ConsumerStore =
   & StoreGetter<ConsumerKey, Consumer>
-  & StoreLister<ConsumerListKey, Pick<Consumer, 'consumer'|'provider'|'subscription'>>
+  & StoreLister<ConsumerListKey, Pick<Consumer, 'consumer'|'provider'|'subscription'|'customer'>>
 
 export interface Subscription {
   customer: CustomerDID

--- a/billing/lib/ucan-stream.js
+++ b/billing/lib/ucan-stream.js
@@ -80,6 +80,7 @@ export const storeSpaceUsageDeltas = async (deltas, ctx) => {
       diffs.push({
         provider: consumer.provider,
         subscription: consumer.subscription,
+        customer: consumer.customer,
         space: delta.resource,
         cause: delta.cause,
         delta: delta.delta,

--- a/billing/test/helpers/consumer.js
+++ b/billing/test/helpers/consumer.js
@@ -1,4 +1,5 @@
 import { Schema } from '../../data/lib.js'
+import { randomCustomer } from './customer.js'
 import { randomLink } from './dag.js'
 import { randomDID } from './did.js'
 import { randomInteger } from './math.js'
@@ -11,6 +12,7 @@ export const randomConsumer = async (base = {}) => ({
   consumer: await randomDID(),
   provider: Schema.did({ method: 'web' }).from(['did:web:web3.storage', 'did:web:nft.storage'][randomInteger(0, 2)]),
   subscription: randomLink().toString(),
+  customer: randomCustomer().customer,
   cause: randomLink(),
   insertedAt: new Date(),
   updatedAt: new Date(),

--- a/billing/test/helpers/egress.js
+++ b/billing/test/helpers/egress.js
@@ -10,7 +10,7 @@ export const randomEgressEvent = async (customer) => ({
   customer: customer.customer,
   resource: randomLink(),
   bytes: Math.floor(Math.random() * 1000000),
-  // Random timestamp within the last 1 hour
-  servedAt: new Date(Date.now() - Math.floor(Math.random() * 60 * 60 * 1000)),
+  // Random timestamp within the last 3 minutes
+  servedAt: new Date(Date.now() - Math.floor(Math.random() * 3 * 60 * 1000)),
   cause: randomLink()
 })

--- a/billing/test/lib/egress-traffic.js
+++ b/billing/test/lib/egress-traffic.js
@@ -112,7 +112,7 @@ export const test = {
         }, {
           retries: maxRetries,
           minTimeout: delay,
-          factor: 2,
+          factor: 3,
           shouldRetry: err => (err instanceof Error && err.message === 'No aggregated meter event found yet'),
           onFailedAttempt: err => {
             console.log(`${err.message} - Attempt ${err.attemptNumber} failed. There are ${err.retriesLeft} retries left.`);

--- a/billing/utils/stripe.js
+++ b/billing/utils/stripe.js
@@ -102,6 +102,7 @@ export async function recordBillingMeterEvent(stripe, billingMeterEventName, egr
 
   // Identifier is only set if the event was successfully created
   if (meterEvent.identifier) {
+    console.log(`Meter event created: ${meterEvent.identifier}`)
     return { ok: { meterEvent } }
   }
   return {

--- a/upload-api/tables/consumer.js
+++ b/upload-api/tables/consumer.js
@@ -92,7 +92,8 @@ export function useConsumerTable (dynamoDb, tableName) {
         KeyConditionExpression: "consumer = :consumer",
         ExpressionAttributeValues: {
           ':consumer': { S: consumer },
-        }
+        },
+        ProjectionExpression: 'provider, subscription, customer'
       }))
       // we may need to worry about pagination in the future if we end up supporting many many subscriptions for a single
       // provider/consumer pair, but I suspect we'll never get there

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -96,7 +96,7 @@ export const consumerTableProps = {
   },
   primaryIndex: { partitionKey: 'subscription', sortKey: 'provider' },
   globalIndexes: {
-    consumer: { partitionKey: 'consumer', projection: ['provider', 'subscription'] },
+    consumer: { partitionKey: 'consumer', projection: ['provider', 'subscription', 'customer'] },
     provider: { partitionKey: 'provider', projection: ['consumer'] },
     customer: { partitionKey: 'customer', projection: ['consumer', 'provider', 'subscription', 'cause'] },
   }


### PR DESCRIPTION
**Context**

While testing the Egress Tracking System in Staging, an error occurred indicating that the router couldn't resolve the customer:

```
✘ [ERROR] Failed to record egress for space did:key:z6MkkYoZNccuPxDxc8kh6YgPSZwyXCqeS2QYqhtQtYyEKYTt {
    name: 'FieldError',
    message: 'Object contains invalid field "customer":\n' +
      '  - Expected value of type string instead got undefined'
    ...
```

**Issue**

The error arises because the `consumerTable.get` query does not include the `customer` field in its projection, despite the customer existing in `consumerTable` and being manually retrievable.

**Fix**

This PR updates the `consumerTable.get` query to ensure the `customer` field is projected correctly, allowing the router to resolve the customer as expected. It also fixes the related tests to reflect this change accurately.