### PR TITLE
fix: drop consumer index

### DIFF
--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -96,7 +96,8 @@ export const consumerTableProps = {
   },
   primaryIndex: { partitionKey: 'subscription', sortKey: 'provider' },
   globalIndexes: {
-    consumer: { partitionKey: 'consumer', projection: ['provider', 'subscription', 'customer'] },
+    // Disabled the index so the SST can delete it from the table, and we can recreate it with the correct projected attributes
+    // consumer: { partitionKey: 'consumer', projection: ['provider', 'subscription', 'customer'] },
     provider: { partitionKey: 'provider', projection: ['consumer'] },
     customer: { partitionKey: 'customer', projection: ['consumer', 'provider', 'subscription', 'cause'] },
   }


### PR DESCRIPTION
This PR modifies the consumerTable SST code to remove the existing `consumer` GSI configuration, causing the stack to delete the GSI.

We need to delete it first, and then we can recreate it with the same name but with the additional projected attributes.

