### PR TITLE
fix(consumerTable): new consumer index

### DIFF
--- a/billing/tables/consumer.js
+++ b/billing/tables/consumer.js
@@ -8,5 +8,5 @@ import { encodeKey, decode, lister } from '../data/consumer.js'
  */
 export const createConsumerStore = (conf, { tableName }) => ({
   ...createStoreGetterClient(conf, { tableName, encodeKey, decode }),
-  ...createStoreListerClient(conf, { tableName, ...lister, indexName: 'consumer' })
+  ...createStoreListerClient(conf, { tableName, ...lister, indexName: 'consumerV2' })
 })

--- a/upload-api/tables/consumer.js
+++ b/upload-api/tables/consumer.js
@@ -88,7 +88,7 @@ export function useConsumerTable (dynamoDb, tableName) {
     get: async (provider, consumer) => {
       const response = await dynamoDb.send(new QueryCommand({
         TableName: tableName,
-        IndexName: 'consumer',
+        IndexName: 'consumerV2',
         KeyConditionExpression: "consumer = :consumer",
         ExpressionAttributeValues: {
           ':consumer': { S: consumer },

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -96,7 +96,8 @@ export const consumerTableProps = {
   },
   primaryIndex: { partitionKey: 'subscription', sortKey: 'provider' },
   globalIndexes: {
-    consumer: { partitionKey: 'consumer', projection: ['provider', 'subscription', 'customer'] },
+    consumer: { partitionKey: 'consumer', projection: ['provider', 'subscription'] },
+    consumerV2: { partitionKey: 'consumer', projection: ['provider', 'subscription', 'customer'] },
     provider: { partitionKey: 'provider', projection: ['consumer'] },
     customer: { partitionKey: 'customer', projection: ['consumer', 'provider', 'subscription', 'cause'] },
   }


### PR DESCRIPTION
By creating a new Global Secondary Index (GSI) with a different name, we avoid any downtime for existing queries that rely on the current consumer index, and we don’t need to worry about temporarily losing data in that index.

This PR introduces the `consumerV2` index to the `consumerTable` and includes the `customer` attribute in the projection. It also updates the `consumerTable.get` query to use the new index.