### PR TITLE
feat: add upload root CID sampler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23648,7 +23648,8 @@
     },
     "node_modules/one-webcrypto": {
       "version": "1.0.3",
-      "resolved": "git+ssh://git@github.com/web3-storage/one-webcrypto.git#5148cd14d5489a8ac4cd38223870e02db15a2382",
+      "resolved": "https://registry.npmjs.org/one-webcrypto/-/one-webcrypto-1.0.3.tgz",
+      "integrity": "sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q==",
       "license": "MIT"
     },
     "node_modules/onetime": {
@@ -30304,6 +30305,7 @@
         "@web3-storage/upload-api": "^18.1.1",
         "multiformats": "^13.1.0",
         "nanoid": "^5.0.2",
+        "one-webcrypto": "^1.0.3",
         "p-map": "^7.0.2",
         "p-queue": "^8.0.1",
         "p-retry": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12412,9 +12412,9 @@
       }
     },
     "node_modules/@web3-storage/upload-api": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/upload-api/-/upload-api-18.1.1.tgz",
-      "integrity": "sha512-KMsmJYc77PHZuF6vkkTyVPe52YbJCDC6rkjUAUe4AOVeo1OER29OjwqiyaZGz6Jzka7YvlzXWqcDj1A07XqRtw==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@web3-storage/upload-api/-/upload-api-18.1.2.tgz",
+      "integrity": "sha512-C89PHJMtg64YpP7Hm62OC3m28BoMCB3Vz7SpAC7qifOPmxtU8EEUcN4x1dvbZkGW7HMpdDOhHVwWzzHY//G0BQ==",
       "dependencies": {
         "@ucanto/client": "^9.0.1",
         "@ucanto/interface": "^10.0.1",
@@ -12424,7 +12424,7 @@
         "@ucanto/validator": "^9.0.2",
         "@web3-storage/access": "^20.1.0",
         "@web3-storage/blob-index": "^1.0.4",
-        "@web3-storage/capabilities": "^17.4.0",
+        "@web3-storage/capabilities": "^17.4.1",
         "@web3-storage/content-claims": "^5.1.0",
         "@web3-storage/did-mailto": "^2.1.0",
         "@web3-storage/filecoin-api": "^7.3.2",
@@ -30302,7 +30302,7 @@
         "@web3-storage/access": "^20.0.0",
         "@web3-storage/capabilities": "^17.4.1",
         "@web3-storage/did-mailto": "^2.1.0",
-        "@web3-storage/upload-api": "^18.1.1",
+        "@web3-storage/upload-api": "^18.1.2",
         "multiformats": "^13.1.0",
         "nanoid": "^5.0.2",
         "one-webcrypto": "^1.0.3",

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -171,6 +171,7 @@ export function UploadApiStack({ stack, app }) {
         'GET /storefront-cron': 'upload-api/functions/storefront-cron.handler',
         // AWS API Gateway does not know trailing slash... and Grafana Agent puts trailing slash
         'GET /metrics/{proxy+}': 'upload-api/functions/metrics.handler',
+        'GET /sample': 'upload-api/functions/sample.handler',
       },
       accessLog: {
         format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'

--- a/upload-api/functions/sample.js
+++ b/upload-api/functions/sample.js
@@ -1,0 +1,38 @@
+import * as Sentry from '@sentry/serverless'
+import * as dagJSON from '@ipld/dag-json'
+import * as Monitor from '../monitor.js'
+import { mustGetEnv } from '../../lib/env.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
+
+/**
+ * AWS HTTP Gateway handler for GET /sample.
+ *
+ * @param {{ queryStringParameters?: import('aws-lambda').APIGatewayProxyEventQueryStringParameters }} event
+ */
+export const sampleGet = async (event) => {
+  const dynamo = getDynamoClient({ region: process.env.AWS_REGION ?? 'us-west-2' })
+  const tableName = mustGetEnv('UPLOAD_TABLE_NAME')
+
+  /** @type {number|undefined} */
+  let size
+  if (event.queryStringParameters?.size) {
+    size = parseInt(event.queryStringParameters.size)
+    size = isNaN(size) ? undefined : size
+  }
+
+  const samples = []
+  for await (const sample of Monitor.sampleUploads(dynamo, tableName, { size })) {
+    samples.push(sample)
+  }
+
+  const body = Buffer.from(dagJSON.encode(samples)).toString('base64')
+  return { statusCode: 200, body }
+}
+
+export const handler = Sentry.AWSLambda.wrapHandler((event) => sampleGet(event))

--- a/upload-api/monitor.js
+++ b/upload-api/monitor.js
@@ -1,0 +1,55 @@
+/** Tools for monitoring the upload-api. */
+import { code as dagPBCode } from '@ipld/dag-pb'
+import { code as rawCode } from 'multiformats/codecs/raw'
+import * as Link from 'multiformats/link'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { ScanCommand } from '@aws-sdk/client-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+import * as ed25519 from '@ucanto/principal/ed25519'
+
+const MAX_SAMPLE_SIZE = 10
+const SAMPLE_SIZE = 1
+
+const codes = [dagPBCode, rawCode]
+
+/** @param {number} max */
+const randomInt = max => Math.floor(Math.random() * max)
+
+const randomCodec = () => codes[randomInt(codes.length)]
+
+const randomLink = async () => {
+  const digest = await sha256.digest(crypto.getRandomValues(new Uint8Array(256)))
+  return Link.create(randomCodec(), digest)
+}
+
+const randomDID = async () => {
+  const signer = await ed25519.generate()
+  return signer.did()
+}
+
+/**
+ * Get a random sample of registered upload root CIDs. Currently filtered to
+ * codecs that can be served natively by an IPFS gateway (raw and dag-pb).
+ *
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamo
+ * @param {string} tableName
+ * @param {{ size?: number }} [options]
+ */
+export const sampleUploads = async function * (dynamo, tableName, options) {
+  const size = Math.min(options?.size ?? SAMPLE_SIZE, MAX_SAMPLE_SIZE)
+  let i = 0
+  while (i < size) {
+    const [root, space] = await Promise.all([randomLink(), randomDID()])
+    const res = await dynamo.send(new ScanCommand({
+      TableName: tableName,
+      IndexName: 'cid',
+      Limit: 1,
+      ExclusiveStartKey: marshall({ root: root.toString(), space })
+    }))
+    if (!res.Items?.length) continue
+
+    const raw = unmarshall(res.Items[0])
+    yield { root: Link.parse(raw.root) }
+    i++
+  }
+}

--- a/upload-api/monitor.js
+++ b/upload-api/monitor.js
@@ -6,6 +6,7 @@ import { sha256 } from 'multiformats/hashes/sha2'
 import { ScanCommand } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import * as ed25519 from '@ucanto/principal/ed25519'
+import { webcrypto } from 'one-webcrypto'
 
 const MAX_SAMPLE_SIZE = 10
 const SAMPLE_SIZE = 1
@@ -18,7 +19,8 @@ const randomInt = max => Math.floor(Math.random() * max)
 const randomCodec = () => codes[randomInt(codes.length)]
 
 const randomLink = async () => {
-  const digest = await sha256.digest(crypto.getRandomValues(new Uint8Array(256)))
+  const bytes = webcrypto.getRandomValues(new Uint8Array(256))
+  const digest = await sha256.digest(bytes)
   return Link.create(randomCodec(), digest)
 }
 

--- a/upload-api/monitor.js
+++ b/upload-api/monitor.js
@@ -13,20 +13,14 @@ const SAMPLE_SIZE = 1
 
 const codes = [dagPBCode, rawCode]
 
-/** @param {number} max */
-const randomInt = max => Math.floor(Math.random() * max)
+const randomCodec = () => codes[Math.floor(Math.random() * codes.length)]
 
-const randomCodec = () => codes[randomInt(codes.length)]
+const randomDID = async () => (await ed25519.generate()).did()
 
 const randomLink = async () => {
   const bytes = webcrypto.getRandomValues(new Uint8Array(256))
   const digest = await sha256.digest(bytes)
   return Link.create(randomCodec(), digest)
-}
-
-const randomDID = async () => {
-  const signer = await ed25519.generate()
-  return signer.did()
 }
 
 /**

--- a/upload-api/package.json
+++ b/upload-api/package.json
@@ -25,7 +25,7 @@
     "@web3-storage/access": "^20.0.0",
     "@web3-storage/capabilities": "^17.4.1",
     "@web3-storage/did-mailto": "^2.1.0",
-    "@web3-storage/upload-api": "^18.1.1",
+    "@web3-storage/upload-api": "^18.1.2",
     "multiformats": "^13.1.0",
     "nanoid": "^5.0.2",
     "one-webcrypto": "^1.0.3",

--- a/upload-api/package.json
+++ b/upload-api/package.json
@@ -28,6 +28,7 @@
     "@web3-storage/upload-api": "^18.1.1",
     "multiformats": "^13.1.0",
     "nanoid": "^5.0.2",
+    "one-webcrypto": "^1.0.3",
     "p-map": "^7.0.2",
     "p-queue": "^8.0.1",
     "p-retry": "^6.2.0",

--- a/upload-api/test/helpers/random.js
+++ b/upload-api/test/helpers/random.js
@@ -5,6 +5,7 @@ import * as Link from 'multiformats/link'
 import * as raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as CAR from '@ucanto/transport/car'
+import * as ed25519 from '@ucanto/principal/ed25519'
 
 /** @param {number} size */
 export async function randomBytes(size) {
@@ -54,4 +55,9 @@ export async function randomCAR(size) {
   const cid = await CAR.codec.link(new Uint8Array(await blob.arrayBuffer()))
 
   return Object.assign(blob, { cid, roots: [root] })
+}
+
+export const randomDID = async () => {
+  const signer = await ed25519.generate()
+  return signer.did()
 }

--- a/upload-api/test/monitor.test.js
+++ b/upload-api/test/monitor.test.js
@@ -14,9 +14,7 @@ const test = /** @type {TestFn} */ (anyTest)
 test.before(async t => {
   const dynamo = await createDynamodDb()
   const tableName = await createTable(dynamo, uploadTableProps)
-
   const uploadTable = useUploadTable(dynamo, tableName)
-
   Object.assign(t.context, { dynamo, uploadTable, tableName })
 })
 

--- a/upload-api/test/monitor.test.js
+++ b/upload-api/test/monitor.test.js
@@ -1,0 +1,45 @@
+import anyTest from 'ava'
+import { uploadTableProps } from '../tables/index.js'
+import { createDynamodDb, createTable } from './helpers/resources.js'
+import { useUploadTable } from '../tables/upload.js'
+import { randomCID, randomDID } from './helpers/random.js'
+import * as Monitor from '../monitor.js'
+
+/**
+ * @typedef {{ tableName: string, uploadTable: import('@web3-storage/upload-api').UploadTable }} Context
+ * @typedef {import('ava').TestFn<import('./helpers/context.js').DynamoContext & Context>} TestFn
+ */
+const test = /** @type {TestFn} */ (anyTest)
+
+test.before(async t => {
+  const dynamo = await createDynamodDb()
+  const tableName = await createTable(dynamo, uploadTableProps)
+
+  const uploadTable = useUploadTable(dynamo, tableName)
+
+  Object.assign(t.context, { dynamo, uploadTable, tableName })
+})
+
+test('should retrieve a random sample of upload root CIDs', async t => {
+  const { dynamo, tableName, uploadTable } = t.context
+
+  const uploads = []
+  for (let i = 0; i < 10; i++) {
+    const [space, root, issuer, invocation] =
+      await Promise.all([randomDID(), randomCID(), randomDID(), randomCID()])
+    const upload = { space, root, issuer, invocation }
+    const res = await uploadTable.upsert(upload)
+    t.truthy(res.ok)
+    uploads.push(upload)
+  }
+
+  const samples = []
+  for await (const s of Monitor.sampleUploads(dynamo, tableName, { size: 3 })) {
+    samples.push(s)
+  }
+
+  t.is(samples.length, 3)
+  for (const sample of samples) {
+    t.true(uploads.some(u => u.root.toString() === sample.root.toString()))
+  }
+})


### PR DESCRIPTION
Adds a new endpoint `/sample` which outputs a `dag-json` encoded array of root CIDs registered by users, filtered by codecs the gateway renders natively (`dag-pb` and `raw`).

The endpoint accepts a `?size=` querystring to allow up to 10 CIDs to be retrieved.

This can be used for retrieval testing.