### PR TITLE
fix(egress-tracking): new partition and sort key for dynamo table

### DIFF
--- a/billing/lib/api.ts
+++ b/billing/lib/api.ts
@@ -189,7 +189,12 @@ export type EgressTrafficQueue = QueueAdder<EgressTrafficData>
 /**
  * List key for egress traffic data.
  */
-export interface EgressTrafficEventListKey { space: ConsumerDID, customer: CustomerDID, from: Date }
+export interface EgressTrafficEventListKey { 
+  space: ConsumerDID, 
+  resource: UnknownLink,
+  servedAt: Date
+  cause: UnknownLink,
+}
 
 /**
  * Captures details about a space that should be billed for a given customer in

--- a/billing/tables/egress-traffic.js
+++ b/billing/tables/egress-traffic.js
@@ -8,6 +8,10 @@ import { validate, encode, lister, decode } from '../data/egress.js'
  */
 export const egressTrafficTableProps = {
   fields: {
+    /** Composite key with format: "space#resource" */
+    pk: 'string',
+    /** Composite key with format: "servedAt#cause" */
+    sk: 'string',
     /** Space DID (did:key:...). */
     space: 'string',
     /** Customer DID (did:mailto:...). */
@@ -21,11 +25,11 @@ export const egressTrafficTableProps = {
     /** UCAN invocation ID that caused the egress traffic. */
     cause: 'string',
   },
-  primaryIndex: { partitionKey: 'space', sortKey: 'servedAt' },
+  primaryIndex: { partitionKey: 'pk', sortKey: 'sk' },
   globalIndexes: {
     customer: {
       partitionKey: 'customer',
-      sortKey: 'servedAt',
+      sortKey: 'sk',
       projection: ['space', 'resource', 'bytes', 'cause', 'servedAt']
     }
   }

--- a/billing/test/helpers/context.js
+++ b/billing/test/helpers/context.js
@@ -191,7 +191,7 @@ export const createEgressTrafficTestContext = async () => {
     })
   }
 
-  const egressTrafficTable = await createTable(awsServices.dynamo.client, egressTrafficTableProps, 'egress-traffic-')
+  const egressTrafficTable = await createTable(awsServices.dynamo.client, egressTrafficTableProps, 'egress-traffic-events-')
   const egressTrafficEventStore = {
     ...createEgressTrafficEventStore(awsServices.dynamo.client, { tableName: egressTrafficTable }),
     ...createStorePutterClient(awsServices.dynamo.client, {

--- a/billing/utils/stripe.js
+++ b/billing/utils/stripe.js
@@ -91,12 +91,14 @@ export async function recordBillingMeterEvent(stripe, billingMeterEventName, egr
     event_name: billingMeterEventName,
     payload: {
       stripe_customer_id: stripeCustomerId,
+      // Stripe expects the value to be a string
       value: egressData.bytes.toString(),
     },
+    // Stripe expects the timestamp to be in seconds
     timestamp: Math.floor(egressData.servedAt.getTime() / 1000),
   },
     {
-      idempotencyKey: `${egressData.servedAt.toISOString()}-${egressData.space}-${egressData.customer}-${egressData.resource}`
+      idempotencyKey: `${egressData.servedAt.toISOString()}-${egressData.space}-${egressData.customer}-${egressData.resource}-${egressData.cause}`
     }
   )
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "npm@10.8.2+sha256.c8c61ba0fa0ab3b5120efd5ba97fdaf0e0b495eef647a97c4413919eda0a878b",
   "type": "module",
   "scripts": {
-    "start": "sst start",
+    "start": "sst dev",
     "build": "sst build",
     "check": "tsc --build",
     "deploy": "sst deploy --outputs-file .test-env.json",

--- a/stacks/billing-db-stack.js
+++ b/stacks/billing-db-stack.js
@@ -16,7 +16,7 @@ export const BillingDbStack = ({ stack }) => {
     ...usageTableProps,
     stream: 'new_image'
   })
-  const egressTrafficTable = new Table(stack, 'egress-traffic', egressTrafficTableProps)
+  const egressTrafficTable = new Table(stack, 'egress-traffic-events', egressTrafficTableProps)
 
   stack.addOutputs({
     customerTableName: customerTable.tableName,

--- a/stacks/billing-stack.js
+++ b/stacks/billing-stack.js
@@ -202,7 +202,7 @@ export function BillingStack ({ stack, app }) {
     consumer: {
       function: egressTrafficQueueHandler,
       deadLetterQueue: egressTrafficDLQ.cdk.queue,
-      cdk: { eventSource: { batchSize: 1 } }
+      cdk: { eventSource: { batchSize: 10 } }
     },
     cdk: { queue: { visibilityTimeout: Duration.minutes(15) } }
   })

--- a/upload-api/stores/usage.js
+++ b/upload-api/stores/usage.js
@@ -82,7 +82,10 @@ export function useUsageStore({ spaceSnapshotStore, spaceDiffStore, egressTraffi
       }
 
       const result = await egressTrafficQueue.add(record)
-      if (result.error) return result
+      if (result.error) {
+        console.error('Error sending egress event to queue:', result.error)
+        return result
+      }
 
       return { ok: { ...record, servedAt: servedAt.toISOString() } }
     }


### PR DESCRIPTION
**Context**
I've identified an issue in our DynamoDB table where egress events were not being stored correctly. This was traced back to the configuration of our partition key (PK) and sort key (SK). In DynamoDB, the partition key is crucial for uniquely identifying each item, while the sort key helps organize data within a partition. 

This change ensures that the combination of partition key and sort key is unique for each record, preventing DynamoDB from overriding existing records in case of a collision.

**Changes Made**

1. **Modification of Partition Key (PK) & Sort Key (SK):** 
   - The PK was updated to ensure it uniquely identifies each record. Previously, key collisions occurred because multiple records were using the same PK value, leading to storage issues.

2. **Inclusion of `cause` in Stripe Idempotent Key:**
   - Added `cause` as part of the Stripe idempotent key to ensure the uniqueness of requests to Stripe, preventing duplicate processing.

3. **Renaming of Table from `egress-traffic` to `egress-traffic-events`:**
   - Since existing partition keys and sort keys cannot be updated, the table was renamed and the keys were updated. The existing table will be dropped to accommodate these changes.

**Impact**
- These changes resolve the storage issues for egress events and improve data integrity and retrieval efficiency.
- The renaming and restructuring of the table ensure that future records are stored and managed correctly.

Blocked by https://github.com/storacha/w3up/pull/1588