### PR TITLE
fix: disable tracing across the board

### DIFF
--- a/billing/functions/billing-cron.js
+++ b/billing/functions/billing-cron.js
@@ -9,7 +9,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0
+  tracesSampleRate: 0
 })
 
 /**

--- a/billing/functions/customer-billing-queue.js
+++ b/billing/functions/customer-billing-queue.js
@@ -10,7 +10,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0
+  tracesSampleRate: 0
 })
 
 /**

--- a/billing/functions/space-billing-queue.js
+++ b/billing/functions/space-billing-queue.js
@@ -10,7 +10,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0
+  tracesSampleRate: 0
 })
 
 /**

--- a/billing/functions/stripe.js
+++ b/billing/functions/stripe.js
@@ -13,7 +13,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 export const webhook = Sentry.AWSLambda.wrapHandler(

--- a/billing/functions/ucan-stream.js
+++ b/billing/functions/ucan-stream.js
@@ -11,7 +11,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0
+  tracesSampleRate: 0
 })
 
 /**

--- a/billing/functions/usage-table.js
+++ b/billing/functions/usage-table.js
@@ -9,7 +9,7 @@ import { expect } from './lib.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0
+  tracesSampleRate: 0
 })
 
 /**

--- a/carpark/event-bus/eipfs-indexer.js
+++ b/carpark/event-bus/eipfs-indexer.js
@@ -9,7 +9,7 @@ const SQS_INDEXER_QUEUE_REGION = 'us-west-2'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/carpark/functions/carpark-bucket-event.js
+++ b/carpark/functions/carpark-bucket-event.js
@@ -6,7 +6,7 @@ import { notifyBus } from '../event-bus/source.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const EVENT_BUS_ARN = process.env.EVENT_BUS_ARN || ''

--- a/filecoin/functions/handle-cron-tick.js
+++ b/filecoin/functions/handle-cron-tick.js
@@ -14,7 +14,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'

--- a/filecoin/functions/handle-filecoin-submit-message.js
+++ b/filecoin/functions/handle-filecoin-submit-message.js
@@ -10,7 +10,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'

--- a/filecoin/functions/handle-piece-insert-to-content-claim.js
+++ b/filecoin/functions/handle-piece-insert-to-content-claim.js
@@ -14,7 +14,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/filecoin/functions/handle-piece-insert-to-filecoin-submit.js
+++ b/filecoin/functions/handle-piece-insert-to-filecoin-submit.js
@@ -14,7 +14,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/filecoin/functions/handle-piece-offer-message.js
+++ b/filecoin/functions/handle-piece-offer-message.js
@@ -13,7 +13,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/filecoin/functions/handle-piece-status-update.js
+++ b/filecoin/functions/handle-piece-status-update.js
@@ -14,7 +14,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/filecoin/functions/metrics-aggregate-offer-and-accept-total.js
+++ b/filecoin/functions/metrics-aggregate-offer-and-accept-total.js
@@ -11,7 +11,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'

--- a/filecoin/functions/piece-cid-compute.js
+++ b/filecoin/functions/piece-cid-compute.js
@@ -13,7 +13,7 @@ import { getS3Client } from '../../lib/aws/s3.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/indexer/functions/handle-block-advert-publish-message.js
+++ b/indexer/functions/handle-block-advert-publish-message.js
@@ -9,7 +9,7 @@ import { getSQSClient } from '../../lib/aws/sqs.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/indexer/functions/handle-block-index-writer-message.js
+++ b/indexer/functions/handle-block-index-writer-message.js
@@ -9,7 +9,7 @@ import { getDynamoClient } from '../../lib/aws/dynamo.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/replicator/functions/replicator.js
+++ b/replicator/functions/replicator.js
@@ -8,7 +8,7 @@ import { getS3Client } from '../../lib/aws/s3.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -9,7 +9,7 @@ import { getS3Client } from '../../lib/aws/s3.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/upload-api/functions/admin-metrics.js
+++ b/upload-api/functions/admin-metrics.js
@@ -12,7 +12,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'

--- a/upload-api/functions/bridge.js
+++ b/upload-api/functions/bridge.js
@@ -13,7 +13,7 @@ import { streamToArrayBuffer, stringToStream } from '../bridge/streams.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 /**

--- a/upload-api/functions/get.js
+++ b/upload-api/functions/get.js
@@ -6,7 +6,7 @@ import { getServiceSigner } from '../config.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const repo = 'https://github.com/web3-storage/w3infra'

--- a/upload-api/functions/metrics.js
+++ b/upload-api/functions/metrics.js
@@ -22,7 +22,7 @@ import { createMetricsTable } from '../tables/metrics.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'

--- a/upload-api/functions/receipt.js
+++ b/upload-api/functions/receipt.js
@@ -7,7 +7,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 

--- a/upload-api/functions/space-metrics.js
+++ b/upload-api/functions/space-metrics.js
@@ -12,7 +12,7 @@ import { mustGetEnv } from '../../lib/env.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'

--- a/upload-api/functions/storefront-cron.js
+++ b/upload-api/functions/storefront-cron.js
@@ -4,7 +4,7 @@ import { handleCronTick } from '../../filecoin/functions/handle-cron-tick.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 export const handler = Sentry.AWSLambda.wrapHandler(handleCronTick)

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -47,7 +47,7 @@ import * as UCantoValidator from '@ucanto/validator'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 export { API }

--- a/upload-api/functions/ucan.js
+++ b/upload-api/functions/ucan.js
@@ -6,7 +6,7 @@ import * as AgentStore from '../stores/agent.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'

--- a/upload-api/service.js
+++ b/upload-api/service.js
@@ -4,7 +4,7 @@ import * as UploadAPI from '@web3-storage/upload-api'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0,
 })
 
 export const createServiceRouter = UploadAPI.createService


### PR DESCRIPTION
We currently can't use Sentry's tracing functionality because we overrun our tracing data quota within hours. I'm disabling all tracing and plan on re-enabling it across the board once I've worked out how to use it for the debugging tasks I have on my plate right now.

Note that this **does not** disable error reporting - that's a separate configuration option and this just disables tracing:

https://docs.sentry.io/platforms/javascript/tracing/

My end goal for this is to have tracing configured at a reasonable percentage for each lambda - most will probably end up around 0.1 but some higher volume functions may need even lower settings.