### PR TITLE
feat: trace all UCAN invocation traffic

### DIFF
--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -47,7 +47,7 @@ import * as UCantoValidator from '@ucanto/validator'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 0,
+  tracesSampleRate: 1,
 })
 
 export { API }

--- a/upload-api/functions/ucan.js
+++ b/upload-api/functions/ucan.js
@@ -6,7 +6,7 @@ import * as AgentStore from '../stores/agent.js'
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 0,
+  tracesSampleRate: 1,
 })
 
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'


### PR DESCRIPTION
I'd like to track down the UCAN pipeline WriteError issue we've been seeing in production, so enable 100% tracing for both of the related Lambdas in hopes that this will give me maximal information about the code the error is in.