### PR TITLE
feat: add CORS Access-Control-Max-Age header

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -177,6 +177,12 @@ export function UploadApiStack({ stack, app }) {
       },
       accessLog: {
         format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'
+      },
+      cors: {
+        allowHeaders: ['*'],
+        allowMethods: ['ANY'],
+        allowOrigins: ['*'],
+        maxAge: '1 day'
       }
     });
   })

--- a/test/blob.test.js
+++ b/test/blob.test.js
@@ -256,7 +256,7 @@ test('blob integration flow with receipts validation', async t => {
   const gatewayRetries = 5
   for (let i = 0; i < gatewayRetries; i++) {
     const controller = new AbortController()
-    const timeoutID = setTimeout(() => controller.abort(), 20_000)
+    const timeoutID = setTimeout(() => controller.abort(), 5000)
     try {
       const res = await fetch(gatewayURL, { method: 'HEAD', signal: controller.signal })
       if (res.status === 200) break
@@ -266,7 +266,7 @@ test('blob integration flow with receipts validation', async t => {
     } finally {
       clearTimeout(timeoutID)
     }
-    await new Promise(resolve => setTimeout(resolve, 5000))
+    await new Promise(resolve => setTimeout(resolve, 1000))
   }
 
   // Verify hoverboard can resolved uploaded root via Bitswap

--- a/test/blob.test.js
+++ b/test/blob.test.js
@@ -256,7 +256,7 @@ test('blob integration flow with receipts validation', async t => {
   const gatewayRetries = 5
   for (let i = 0; i < gatewayRetries; i++) {
     const controller = new AbortController()
-    const timeoutID = setTimeout(() => controller.abort(), 10_000)
+    const timeoutID = setTimeout(() => controller.abort(), 20_000)
     try {
       const res = await fetch(gatewayURL, { method: 'HEAD', signal: controller.signal })
       if (res.status === 200) break
@@ -266,7 +266,7 @@ test('blob integration flow with receipts validation', async t => {
     } finally {
       clearTimeout(timeoutID)
     }
-    await new Promise(resolve => setTimeout(resolve, 1000))
+    await new Promise(resolve => setTimeout(resolve, 5000))
   }
 
   // Verify hoverboard can resolved uploaded root via Bitswap

--- a/test/blob.test.js
+++ b/test/blob.test.js
@@ -256,7 +256,7 @@ test('blob integration flow with receipts validation', async t => {
   const gatewayRetries = 5
   for (let i = 0; i < gatewayRetries; i++) {
     const controller = new AbortController()
-    const timeoutID = setTimeout(() => controller.abort(), 5000)
+    const timeoutID = setTimeout(() => controller.abort(), 10_000)
     try {
       const res = await fetch(gatewayURL, { method: 'HEAD', signal: controller.signal })
       if (res.status === 200) break


### PR DESCRIPTION
Configures the UCAN service to send `Access-Control-Max-Age` header allowing the `OPTIONS` response to be cached for 1 day.

Also be explicit about other CORS headers we send.