### PR TITLE
fix: add a bit more logging to help track down usage billing bugs

### DIFF
--- a/billing/functions/usage-table.js
+++ b/billing/functions/usage-table.js
@@ -54,6 +54,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(
 const parseUsageInsertEvent = event => {
   const records = []
   for (const r of event.Records) {
+    console.log(`processing usage record: ${JSON.stringify(r)}`)
     if (r.eventName !== 'INSERT') continue
     if (!r.dynamodb) continue
     if (!r.dynamodb.NewImage) throw new Error('missing "NEW_IMAGE" in stream event')

--- a/billing/functions/usage-table.js
+++ b/billing/functions/usage-table.js
@@ -28,7 +28,9 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     if (!stripeSecretKey) throw new Error('missing secret: STRIPE_SECRET_KEY')
 
     const records = parseUsageInsertEvent(event)
-    if (!records.length) return
+    if (!records.length) {
+      throw new Error(`found no records in usage insert event: ${JSON.stringify(event)}`)
+    }
 
     if (records.length > 1) {
       throw new Error(`invalid batch size, expected: 1, actual: ${records.length}`)

--- a/billing/lib/space-billing-queue.js
+++ b/billing/lib/space-billing-queue.js
@@ -75,7 +75,6 @@ export const calculatePeriodUsage = async (instruction, ctx) => {
   }
 
   console.log(`Total size of ${instruction.space} is ${size} bytes @ ${instruction.to.toISOString()}`)
-  console.log(`Total usage of ${instruction.space} is ${usage} bytes @ ${instruction.to.toISOString()}`)
 
   return { ok: { size, usage } }
 }
@@ -107,7 +106,7 @@ export const storeSpaceUsage = async (instruction, { size, usage }, ctx) => {
   if (snapPut.error) return snapPut
 
   const duration = instruction.to.getTime() - instruction.from.getTime()
-  console.log(`Space consumed ${usage} byte/ms (~${new Big(usage.toString()).div(duration).div(GB).toFixed(2)} GiB/month)`)
+  console.log(`Space consumed by ${instruction.space} is ${usage} byte/ms (~${new Big(usage.toString()).div(duration).div(GB).toFixed(2)} GiB/month)`)
   const usagePut = await ctx.usageStore.put({
     ...instruction,
     usage,

--- a/billing/lib/space-billing-queue.js
+++ b/billing/lib/space-billing-queue.js
@@ -63,7 +63,7 @@ export const calculatePeriodUsage = async (instruction, ctx) => {
   let size = snap?.size ?? 0n
   let usage = size * BigInt(instruction.to.getTime() - instruction.from.getTime())
 
-  console.log(`Total size is ${size} bytes @ ${instruction.from.toISOString()}`)
+  console.log(`Total size of ${instruction.space} is ${size} bytes @ ${instruction.from.toISOString()}`)
 
   for await (const page of iterateSpaceDiffs(instruction, ctx)) {
     if (page.error) return page
@@ -74,7 +74,8 @@ export const calculatePeriodUsage = async (instruction, ctx) => {
     }
   }
 
-  console.log(`Total size is ${size} bytes @ ${instruction.to.toISOString()}`)
+  console.log(`Total size of ${instruction.space} is ${size} bytes @ ${instruction.to.toISOString()}`)
+  console.log(`Total usage of ${instruction.space} is ${usage} bytes @ ${instruction.to.toISOString()}`)
 
   return { ok: { size, usage } }
 }


### PR DESCRIPTION
For some reason some space snapshots have been missed in the past, despite seemingly being in the DB and showing up in dry run.

Also throw if the usage table queue gets an empty message - if this is happening I'd like to understand why, and I'm suspicious that some of our usage tracking issues are messages that are somehow being created with no records.