### PR TITLE
fix: multiple space diffs

### DIFF
--- a/billing/lib/ucan-stream.js
+++ b/billing/lib/ucan-stream.js
@@ -82,7 +82,6 @@ export const storeSpaceUsageDeltas = async (deltas, ctx) => {
     // could have multiple providers for the same consumer (space).
     const consumers = consumerList.ok.results
     console.log(`Found ${consumers.length} consumers for ${delta.resource}`)
-    console.log(`agentMessage (cause): ${delta.cause}`)
     for (const consumer of consumers) {
       diffs.push({
         provider: consumer.provider,

--- a/billing/lib/ucan-stream.js
+++ b/billing/lib/ucan-stream.js
@@ -19,9 +19,9 @@ export const findSpaceUsageDeltas = messages => {
     let resource
     /** @type {number|undefined} */
     let size
-    if (isReceiptForCapability(message, ServiceBlobCaps.allocate) && isServiceBlobAllocateSuccess(message.out)) {
+    if (isReceiptForCapability(message, ServiceBlobCaps.accept) && isServiceBlobAcceptSuccess(message.out)) {
       resource = message.value.att[0].nb?.space
-      size = message.out.ok.size
+      size = message.value.att[0].nb?.blob.size
     } else if (isReceiptForCapability(message, BlobCaps.remove) && isBlobRemoveSuccess(message.out)) {
       resource = /** @type {import('@ucanto/interface').DID} */ (message.value.att[0].with)
       size = -message.out.ok.size
@@ -82,6 +82,7 @@ export const storeSpaceUsageDeltas = async (deltas, ctx) => {
     // could have multiple providers for the same consumer (space).
     const consumers = consumerList.ok.results
     console.log(`Found ${consumers.length} consumers for ${delta.resource}`)
+    console.log(`agentMessage (cause): ${delta.cause}`)
     for (const consumer of consumers) {
       diffs.push({
         provider: consumer.provider,
@@ -118,14 +119,14 @@ const isReceipt = m => m.type === 'receipt'
 
 /**
  * @param {import('@ucanto/interface').Result} r
- * @returns {r is { ok: import('@web3-storage/capabilities/types').BlobAllocateSuccess }}
+ * @returns {r is { ok: import('@web3-storage/capabilities/types').BlobAcceptSuccess }}
  */
-const isServiceBlobAllocateSuccess = r =>
+const isServiceBlobAcceptSuccess = (r) =>
   !r.error &&
   r.ok != null &&
   typeof r.ok === 'object' &&
-  'size' in r.ok &&
-  (typeof r.ok.size === 'number')
+  'site' in r.ok &&
+  typeof r.ok.site === 'object'
 
 /**
  * @param {import('@ucanto/interface').Result} r

--- a/billing/test/lib/ucan-stream.js
+++ b/billing/test/lib/ucan-stream.js
@@ -29,7 +29,7 @@ export const test = {
 
     /**
      * @type {import('../../lib/api.js').UcanReceiptMessage<[
-     *   | import('@web3-storage/capabilities/types').BlobAllocate
+     *   | import('@web3-storage/capabilities/types').BlobAccept
      *   | import('@web3-storage/capabilities/types').BlobRemove
      *   | import('@web3-storage/capabilities/types').StoreAdd
      *   | import('@web3-storage/capabilities/types').StoreRemove
@@ -42,20 +42,25 @@ export const test = {
       value: {
         att: [{
           with: await randomDIDKey(),
-          can: ServiceBlobCaps.allocate.can,
+          can: ServiceBlobCaps.accept.can,
           nb: {
+            _put: {
+              "ucan/await": [
+                ".out.ok",
+                randomLink()
+              ]
+            },
             blob: {
               digest: randomLink().multihash.bytes,
               size: 138
             },
-            cause: randomLink(),
             space: await randomDIDKey()
           }
         }],
         aud: await randomDID(),
         cid: randomLink()
       },
-      out: { ok: { size: 138 } },
+      out: { ok: { site: randomLink() } },
       ts: new Date()
     }, {
       type: 'receipt',
@@ -118,8 +123,8 @@ export const test = {
     for (const r of receipts) {
       assert.ok(deltas.some(d => (
         d.cause.toString() === r.invocationCid.toString() &&
-        // resource for blob allocate is found in the caveats
-        (r.value.att[0].can === ServiceBlobCaps.allocate.can
+        // resource for blob accept is found in the caveats
+        (r.value.att[0].can === ServiceBlobCaps.accept.can
           ? d.resource === r.value.att[0].nb.space
           : d.resource === r.value.att[0].with)
       )))

--- a/upload-api/stores/agent/stream.js
+++ b/upload-api/stores/agent/stream.js
@@ -86,22 +86,22 @@ export const assert = async (message, { stream, store }) => {
   for (const member of message.index) {
     if (member.invocation) {
       const { task, invocation, message } = member.invocation
+      const data = JSON.stringify({
+        // This is bad naming but not worth a breaking change
+        carCid: message.toString(),
+        task: task.toString(),
+        value: {
+          att: invocation.capabilities,
+          aud: invocation.audience.did(),
+          iss: invocation.issuer.did(),
+          cid: invocation.cid.toString(),
+        },
+        ts: Date.now(),
+        type: stream.workflow.type,
+      })
+
       records.push({
-        Data: UTF8.fromString(
-          JSON.stringify({
-            // This is bad naming but not worth a breaking change
-            carCid: message.toString(),
-            task: task.toString(),
-            value: {
-              att: invocation.capabilities,
-              aud: invocation.audience.did(),
-              iss: invocation.issuer.did(),
-              cid: invocation.cid.toString(),
-            },
-            ts: Date.now(),
-            type: stream.workflow.type,
-          })
-        ),
+        Data: UTF8.fromString(data),
         PartitionKey: partitionKey(member),
       })
     }
@@ -133,24 +133,26 @@ export const assert = async (message, { stream, store }) => {
         console.warn("receipt will not serialize to JSON", "receipt", receipt.out, "error", error)
       }
 
+      const data = JSON.stringify(
+        {
+          carCid: message.toString(),
+          invocationCid: invocation.cid.toString(),
+          task: task.toString(),
+          value: {
+            att: invocation.capabilities,
+            aud: invocation.audience.did(),
+            iss: invocation.issuer.did(),
+            cid: invocation.cid.toString(),
+          },
+          out: receipt.out,
+          ts: Date.now(),
+          type: stream.receipt.type,
+        },
+        (_, value) => (typeof value === 'bigint' ? Number(value) : value)
+      )
+
       records.push({
-        Data: UTF8.fromString(
-          JSON.stringify({
-            // This is bad naming but not worth a breaking change
-            carCid: message.toString(),
-            invocationCid: invocation.cid.toString(),
-            task: task.toString(),
-            value: {
-              att: invocation.capabilities,
-              aud: invocation.audience.did(),
-              iss: invocation.issuer.did(),
-              cid: invocation.cid.toString(),
-            },
-            out: receipt.out,
-            ts: Date.now(),
-            type: stream.receipt.type,
-          }, (_, value) => typeof value === "bigint" ? Number(value) : value )
-        ),
+        Data: UTF8.fromString(data),
         PartitionKey: partitionKey(member),
       })
     }


### PR DESCRIPTION
### Description:
This PR addresses the issue https://github.com/storacha/project-tracking/issues/199, where duplicate space diff entries were being created when uploading a file using `space/blob/add`.

### Problem:
**Context:** When the UCAN invocation router receives a request, it executes the invocation and writes the receipts to the stream, which is then processed by `billing/ucan-stream.js` to populate the diff table.

Unlike `store/add`, `space/blob/add` spawns three additional invocations: `web3.store/blob/allocate`, `http/put`, and `web3.store/blob/accept` before finalizing.  
Due to the way receipts are extracted from agent messages—which are a collection of invocations and receipts without a clear hierarchy—this structure causes the receipt from `web3.store/blob/allocate` to be sent to the stream twice:  
1. Once when it is first invoked.  
2. Again because the `blob/allocate` receipt is embedded within the `blob/add` receipt.  

### Solution:
Change the capability used to track space usage deltas from `BlobAllocate` to `BlobAccept`, as `BlobAccept` does not appear multiple times.  