### PR TITLE
fix: two important usage billing fixes

### DIFF
--- a/stacks/billing-stack.js
+++ b/stacks/billing-stack.js
@@ -1,5 +1,6 @@
 import { use, Cron, Queue, Function, Config, Api } from 'sst/constructs'
 import { StartingPosition, FilterCriteria, FilterRule } from 'aws-cdk-lib/aws-lambda'
+import { SqsDlq } from 'aws-cdk-lib/aws-lambda-event-sources'
 import { Duration } from 'aws-cdk-lib'
 import { UcanInvocationStack } from './ucan-invocation-stack.js'
 import { BillingDbStack } from './billing-db-stack.js'
@@ -142,11 +143,11 @@ export function BillingStack ({ stack, app }) {
         eventSource: {
           batchSize: 1,
           startingPosition: StartingPosition.LATEST,
-          retryAttempts: 10
+          retryAttempts: 10,
+          onFailure: new SqsDlq(usageTableDLQ.cdk.queue)
         }
       },
       filters: [{ eventName: ['INSERT'] }],
-      deadLetterQueue: usageTableDLQ.cdk.queue
     }
   })
 


### PR DESCRIPTION
1) use a CID as an idempotency key - some Stripe usage billing reporting requests were failing because the space DID was much longer than we expected and the idempotency key cannot be more than 255 characters - we were sending ~450 characters in many cases

2) properly configure the "on failure" queue for the usage table handler - the previous config didn't work, and no "on failure" destination was set for this, which is, I suspect, why we can't find any trace of some usage table insert hook invocations