### PR TITLE
fix: switch to arm_64 architecture

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -31,6 +31,7 @@ export default {
 
     app.setDefaultFunctionProps({
       runtime: 'nodejs20.x',
+      architecture: 'arm_64',
       environment: {
         NODE_OPTIONS: '--enable-source-maps',
       },


### PR DESCRIPTION
I did not realise we weren't already using `arm_64`. Turns out this change had been applied to `w3filecoin-infra` and `content-claims` but not here (aside from the PSA stack).

Switching to `arm_64` should reduce lambda costs.