### PR TITLE
feat: add Humanode verification callback

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -75,3 +75,6 @@ INTEGRATION_TESTS_STORAGE_PROVIDER_PROOF = ''
 # Optional - custom gateway to authorize in integration tests (defaults to staging)
 INTEGRATION_TESTS_GATEWAY_DID = ''
 INTEGRATION_TESTS_GATEWAY_ENDPOINT = ''
+
+HUMANODE_TOKEN_ENDPOINT='https://auth.demo-storacha-2025-03-31.oauth2.humanode.io/oauth2/token'
+HUMANODE_CLIENT_ID='e9756297-b2d1-4bbe-a139-a9ad1cdc43ee'

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "catalog:",
+    "jwt-decode": "^4.0.0",
     "sst": "catalog:"
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       aws-cdk-lib:
         specifier: 'catalog:'
         version: 2.171.1(constructs@10.3.0)
+      jwt-decode:
+        specifier: ^4.0.0
+        version: 4.0.0
       sst:
         specifier: 'catalog:'
         version: 2.47.3(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0(aws-crt@1.26.2))(aws-crt@1.26.2))(@jest/transform@29.7.0)(@jest/types@29.6.3)(aws-crt@1.26.2)(babel-jest@29.7.0(@babel/core@7.26.10))(encoding@0.1.13)(typescript@5.8.3)
@@ -7406,6 +7409,10 @@ packages:
 
   just-extend@6.2.0:
     resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -21253,6 +21260,8 @@ snapshots:
   just-extend@4.2.1: {}
 
   just-extend@6.2.0: {}
+
+  jwt-decode@4.0.0: {}
 
   keyv@4.5.4:
     dependencies:

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -43,7 +43,7 @@ export function UploadApiStack({ stack, app }) {
 
   // Get references to constructs created in other stacks
   const { carparkBucket } = use(CarparkStack)
-  const { allocationTable, blobRegistryTable, storeTable, uploadTable, delegationBucket, delegationTable, revocationTable, adminMetricsTable, spaceMetricsTable, consumerTable, subscriptionTable, storageProviderTable, rateLimitTable, pieceTable, privateKey, indexingServiceProof, githubClientSecret, humanodeClientSecret } = use(UploadDbStack)
+  const { allocationTable, blobRegistryTable, humanodeTable, storeTable, uploadTable, delegationBucket, delegationTable, revocationTable, adminMetricsTable, spaceMetricsTable, consumerTable, subscriptionTable, storageProviderTable, rateLimitTable, pieceTable, privateKey, indexingServiceProof, githubClientSecret, humanodeClientSecret } = use(UploadDbStack)
   const { agentIndexBucket, agentMessageBucket, ucanStream } = use(UcanInvocationStack)
   const { customerTable, spaceDiffTable, spaceSnapshotTable, egressTrafficTable, stripeSecretKey } = use(BillingDbStack)
   const { pieceOfferQueue, filecoinSubmitQueue } = use(FilecoinStack)
@@ -70,6 +70,7 @@ export function UploadApiStack({ stack, app }) {
           permissions: [
             allocationTable, // legacy
             blobRegistryTable,
+            humanodeTable,
             storeTable, // legacy
             uploadTable,
             customerTable,
@@ -105,6 +106,7 @@ export function UploadApiStack({ stack, app }) {
             UPLOAD_TABLE_NAME: uploadTable.tableName,
             CONSUMER_TABLE_NAME: consumerTable.tableName,
             CUSTOMER_TABLE_NAME: customerTable.tableName,
+            HUMANODE_TABLE_NAME: humanodeTable.tableName,
             SUBSCRIPTION_TABLE_NAME: subscriptionTable.tableName,
             SPACE_METRICS_TABLE_NAME: spaceMetricsTable.tableName,
             ADMIN_METRICS_TABLE_NAME: adminMetricsTable.tableName,

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -43,7 +43,7 @@ export function UploadApiStack({ stack, app }) {
 
   // Get references to constructs created in other stacks
   const { carparkBucket } = use(CarparkStack)
-  const { allocationTable, blobRegistryTable, storeTable, uploadTable, delegationBucket, delegationTable, revocationTable, adminMetricsTable, spaceMetricsTable, consumerTable, subscriptionTable, storageProviderTable, rateLimitTable, pieceTable, privateKey, indexingServiceProof, githubClientSecret } = use(UploadDbStack)
+  const { allocationTable, blobRegistryTable, storeTable, uploadTable, delegationBucket, delegationTable, revocationTable, adminMetricsTable, spaceMetricsTable, consumerTable, subscriptionTable, storageProviderTable, rateLimitTable, pieceTable, privateKey, indexingServiceProof, githubClientSecret, humanodeClientSecret } = use(UploadDbStack)
   const { agentIndexBucket, agentMessageBucket, ucanStream } = use(UcanInvocationStack)
   const { customerTable, spaceDiffTable, spaceSnapshotTable, egressTrafficTable, stripeSecretKey } = use(BillingDbStack)
   const { pieceOfferQueue, filecoinSubmitQueue } = use(FilecoinStack)
@@ -151,12 +151,15 @@ export function UploadApiStack({ stack, app }) {
             HOSTED_ZONE: hostedZone ?? '',
             GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID ?? '',
             PRINCIPAL_MAPPING: process.env.PRINCIPAL_MAPPING ?? '',
+            HUMANODE_TOKEN_ENDPOINT: process.env.HUMANODE_TOKEN_ENDPOINT ?? '',
+            HUMANODE_CLIENT_ID: process.env.HUMANODE_CLIENT_ID ?? ''
           },
           bind: [
             privateKey,
             ucanInvocationPostbasicAuth,
             stripeSecretKey,
             githubClientSecret,
+            humanodeClientSecret,
             indexingServiceProof,
           ]
         }
@@ -177,6 +180,7 @@ export function UploadApiStack({ stack, app }) {
         'GET /metrics/{proxy+}': 'upload-api/functions/metrics.handler',
         'GET /sample': 'upload-api/functions/sample.handler',
         'GET /oauth/callback': 'upload-api/functions/oauth-callback.handler',
+        'GET /oauth/humanode/callback': 'upload-api/functions/oauth-humanode-callback.handler',
       },
       accessLog: {
         format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'

--- a/stacks/upload-db-stack.js
+++ b/stacks/upload-db-stack.js
@@ -12,7 +12,8 @@ import {
   rateLimitTableProps,
   adminMetricsTableProps,
   spaceMetricsTableProps,
-  storageProviderTableProps
+  storageProviderTableProps,
+  humanodeTableProps
 } from '../upload-api/tables/index.js'
 import {
   pieceTableProps
@@ -35,6 +36,8 @@ export function UploadDbStack({ stack, app }) {
 
   const githubClientSecret = new Config.Secret(stack, 'GITHUB_CLIENT_SECRET')
   const humanodeClientSecret = new Config.Secret(stack, 'HUMANODE_CLIENT_SECRET')
+
+  const humanodeTable = new Table(stack, 'humanode', humanodeTableProps)
 
   /**
    * The allocation table tracks allocated multihashes per space.
@@ -123,6 +126,7 @@ export function UploadDbStack({ stack, app }) {
   return {
     allocationTable,
     blobRegistryTable,
+    humanodeTable,
     storeTable,
     uploadTable,
     pieceTable,

--- a/stacks/upload-db-stack.js
+++ b/stacks/upload-db-stack.js
@@ -34,6 +34,7 @@ export function UploadDbStack({ stack, app }) {
   const indexingServiceProof = new Config.Secret(stack, 'INDEXING_SERVICE_PROOF')
 
   const githubClientSecret = new Config.Secret(stack, 'GITHUB_CLIENT_SECRET')
+  const humanodeClientSecret = new Config.Secret(stack, 'HUMANODE_CLIENT_SECRET')
 
   /**
    * The allocation table tracks allocated multihashes per space.
@@ -136,6 +137,7 @@ export function UploadDbStack({ stack, app }) {
     storageProviderTable,
     privateKey,
     githubClientSecret,
+    humanodeClientSecret,
     indexingServiceProof,
   }
 }

--- a/upload-api/functions/oauth-humanode-callback.js
+++ b/upload-api/functions/oauth-humanode-callback.js
@@ -1,0 +1,326 @@
+import { Config } from 'sst/node/config'
+import * as Sentry from '@sentry/serverless'
+import { base64url } from 'multiformats/bases/base64'
+import { Delegation, ok } from '@ucanto/core'
+import * as Validator from '@ucanto/validator'
+import { Verifier } from '@ucanto/principal'
+import * as Access from '@storacha/capabilities/access'
+import * as DidMailto from '@storacha/did-mailto'
+import { mustGetEnv } from '../../lib/env.js'
+import { createCustomerStore } from '../../billing/tables/customer.js'
+import { getServiceSigner } from '../config.js'
+import { jwtDecode } from "jwt-decode"
+
+
+/**
+ * @import { Endpoints } from '@octokit/types'
+ * @import { Signer, Result } from '@ucanto/interface'
+ * @typedef {{
+ *   getOAuthAccessToken: (params: { code: string }) => Promise<Result<{ access_token: string }>>
+ *   getUser: (params: { accessToken: string }) => Promise<Result<Endpoints['GET /user']['response']['data']>>
+ *   getUserEmails: (params: { accessToken: string }) => Promise<Result<Endpoints['GET /user/emails']['response']['data']>>
+ * }} GitHub
+ * @typedef {{
+ *   serviceSigner: Signer
+ *   customerStore: import('../../billing/lib/api.js').CustomerStore
+ * }} Context
+ */
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 0,
+})
+
+const HUMANODE_TOKEN_ENDPOINT = mustGetEnv('HUMANODE_TOKEN_ENDPOINT')
+const HUMANODE_CLIENT_ID = mustGetEnv('HUMANODE_CLIENT_ID')
+const HUMANODE_CLIENT_SECRET = Config.HUMANODE_CLIENT_SECRET
+
+/**
+ * AWS HTTP Gateway handler for GET /oauth/humanode/callback.
+ *
+ * @param {import('aws-lambda').APIGatewayProxyEventV2} request
+ * @param {import('aws-lambda').Context} [context]
+ */
+export const oauthCallbackGet = async (request, context) => {
+  const {
+    serviceSigner,
+    customerStore,
+  } = getContext(context?.clientContext?.Custom)
+
+  const code = request.queryStringParameters?.code
+  if (!code) {
+    console.error('missing code in query params')
+    return { statusCode: 400, body: 'missing code in query params' }
+  }
+
+  // fetch the auth token from Humanode
+  const tokenResponse = await fetch(HUMANODE_TOKEN_ENDPOINT, {
+    method: 'POST', body: new URLSearchParams(
+      {
+        client_id: HUMANODE_CLIENT_ID,
+        client_secret: HUMANODE_CLIENT_SECRET,
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: `https://${request.headers.host}${request.rawPath}`
+      }
+    )
+  })
+  const tokenResult = await tokenResponse.json()
+  const humanodeIdToken = jwtDecode(tokenResult.id_token)
+  const humanodeId = humanodeIdToken.sub
+  
+  // TODO we need to make sure this humanodeId hasn't been used before
+  // I'm thinking just a dynamo table following our normal patterns
+
+
+  // validate the access/authorize delegation and pull the customer email out of it
+  const extractRes = await Delegation.extract(base64url.decode(request.queryStringParameters?.state ?? ''))
+  if (extractRes.error) {
+    console.error('decoding access/authorize delegation', extractRes.error)
+    return { statusCode: 400, body: 'failed to decode access/authorize delegation' }
+  }
+  const authRequest =
+    /** @type {import('@ucanto/interface').Invocation<import('@storacha/upload-api').AccessAuthorize>} */
+    (extractRes.ok)
+  const accessRes = await Validator.access(authRequest, {
+    capability: Access.authorize,
+    authority: serviceSigner,
+    principal: Verifier,
+    validateAuthorization: () => ok({})
+  })
+  if (accessRes.error) {
+    console.error('validating access/authorize delegation', accessRes.error)
+    return { statusCode: 400, body: 'failed to validate access/authorize delegation' }
+  }
+  const customer = DidMailto.fromEmail(/** @type {`${string}@${string}`} */(accessRes.ok.capability.nb.iss))
+  
+  // add a customer with a trial product
+  const customerPutRes = await customerStore.put({
+    customer,
+    product: 'did:web:trial.storacha.network',
+    details: JSON.stringify({ humanode: { id: humanodeId } }),
+    insertedAt: new Date()
+  })
+  if (!customerPutRes.ok) {
+    console.error(`putting customer: ${customer}`, customerPutRes.error)
+    return { statusCode: 500, body: 'failed to put customer' }
+  }
+
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'text/html' },
+    body: Buffer.from(getResponseHTML()).toString('base64'),
+    isBase64Encoded: true,
+  }
+}
+
+export const handler = Sentry.AWSLambda.wrapHandler((event) => oauthCallbackGet(event))
+
+/**
+ * @param {Context} [customContext]
+ * @returns {Context}
+ */
+const getContext = (customContext) => {
+  if (customContext) return customContext
+
+  const region = process.env.AWS_REGION || 'us-west-2'
+
+  const serviceSigner = getServiceSigner({
+    did: process.env.UPLOAD_API_DID,
+    privateKey: Config.PRIVATE_KEY
+  })
+
+  const customerStore = createCustomerStore({ region }, { tableName: mustGetEnv('CUSTOMER_TABLE_NAME') })
+
+  return {
+    serviceSigner,
+    customerStore,
+  }
+}
+
+
+const getResponseHTML = () => `
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Authorized - Storacha Network</title>
+  </head>
+  <body style="font-family:sans-serif;color:#000">
+    <div style="height:100vh;display:flex;align-items:center;justify-content:center">
+      <div style="text-align:center">
+        <img src="https://w3s.link/ipfs/bafybeihinjwsn3kgjrlpdada4xingozsni3boywlscxspc5knatftauety/storacha-bug.svg" alt="Storacha - Decentralized Hot Storage Layer on Filecoin">
+        <h1 style="font-weight:normal">Authorization Successful</h1>
+        <p>You may now close this window.</p>
+      </div>
+    </div>
+  </body>
+</html>
+`.trim()
+
+
+
+
+
+// return {
+//   statusCode: 302,
+//   headers: {
+//     Location: "http://localhost:3000"
+//   }
+
+// }
+
+
+// const extractRes = await Delegation.extract(base64url.decode(request.queryStringParameters?.state ?? ''))
+// if (extractRes.error) {
+//   console.error('decoding access/authorize delegation', extractRes.error)
+//   return { statusCode: 400, body: 'failed to decode access/authorize delegation' }
+// }
+
+// const authRequest =
+//   /** @type {import('@ucanto/interface').Invocation<import('@storacha/upload-api').AccessAuthorize>} */
+//   (extractRes.ok)
+
+// const accessRes = await Validator.access(authRequest, {
+//   capability: Access.authorize,
+//   authority: serviceSigner,
+//   principal: Verifier,
+//   validateAuthorization: () => ok({})
+// })
+// if (accessRes.error) {
+//   console.error('validating access/authorize delegation', accessRes.error)
+//   return { statusCode: 400, body: 'failed to validate access/authorize delegation' }
+// }
+
+
+// // const accessTokenRes = await github.getOAuthAccessToken({ code })
+// // if (!accessTokenRes.ok) {
+// //   console.error(accessTokenRes.error)
+// //   return { statusCode: 400, body: 'failed to get OAuth access token' }
+// // }
+// // const accessToken = accessTokenRes.ok.access_token
+
+// // const [userRes, userEmailsRes] = await Promise.all([
+// //   github.getUser({ accessToken }),
+// //   github.getUserEmails({ accessToken })
+// // ])
+// // if (!userRes.ok) {
+// //   console.error(userRes.error)
+// //   return { statusCode: 500, body: 'failed to get user profile' }
+// // }
+// // if (!userEmailsRes.ok) {
+// //   console.error(userEmailsRes.error)
+// //   return { statusCode: 500, body: 'failed to get user emails' }
+// // }
+
+// // const user = userRes.ok
+// // const emails = userEmailsRes.ok
+// // const primary = emails.find(e => e.primary && e.verified)
+// // if (!primary) {
+// //   console.error('missing primary verified email', emails)
+// //   return { statusCode: 400, body: 'missing primary verified email' }
+// // }
+
+// // record the auth request and issue a receipt
+// const lifetimeInSeconds = 60 * 15
+// const message = await Message.build({
+//   invocations: [authRequest],
+//   receipts: [
+//     await Receipt.issue({
+//       issuer: serviceSigner,
+//       ran: authRequest,
+//       result: ok({
+//         expiration: Math.floor(Date.now() / 1000) + lifetimeInSeconds,
+//         request: authRequest.cid
+//       })
+//     })
+//   ]
+// })
+// const messageWriteRes = await agentStore.messages.write({
+//   source: await Transport.outbound.encode(message),
+//   data: message,
+//   index: AgentMessage.index(message)
+// })
+// if (messageWriteRes.error) {
+//   console.error(messageWriteRes.error)
+//   return { statusCode: 500, body: 'failed to write access/authorize invocation and receipt' }
+// }
+
+// // pull the email address out of access/authorize
+// const customer = DidMailto.fromEmail(/** @type {`${string}@${string}`} */(accessRes.ok.capability.nb.iss))
+
+// // this can be set to true later on if we get enough signal to trust that this email is really the person it claims to be (like we do with github verified emails)
+// const shouldWeConfirm = false
+// if (shouldWeConfirm) {
+//   const confirmRes = await Access.confirm
+//     .invoke({
+//       issuer: serviceSigner,
+//       // audience same as issuer because this is a service invocation
+//       audience: serviceSigner,
+//       // Because with is set to our DID no other actor will be able to issue
+//       // this delegation without our private key.
+//       with: serviceSigner.did(),
+//       lifetimeInSeconds,
+//       // We link to the authorization request so that this attestation can
+//       // not be used to authorize a different request.
+//       nb: {
+//         // we copy request details and set the `aud` field to the agent DID
+//         // that requested the authorization.
+//         iss: customer,
+//         att: authRequest.capabilities[0].nb.att,
+//         aud: authRequest.capabilities[0].with,
+//         // Link to the invocation that requested the authorization.
+//         cause: authRequest.cid,
+//       },
+//     })
+//     .execute(getServiceConnection())
+
+//   if (!confirmRes.out.ok) {
+//     console.error('executing access/confirm', confirmRes.out.error)
+//     return { statusCode: 500, body: 'failed to execute access/confirm invocation' }
+//   }
+// }
+
+
+// const customerGetRes = await customerStore.get({ customer })
+// if (customerGetRes.ok) {
+//   return {
+//     statusCode: 200,
+//     headers: { 'Content-Type': 'text/html' },
+//     body: Buffer.from(getResponseHTML()).toString('base64'),
+//     isBase64Encoded: true,
+//   }
+// }
+
+// if (customerGetRes.error.name !== 'RecordNotFound') {
+//   console.error(`getting customer: ${customer}`, customerGetRes.error)
+//   return { statusCode: 500, body: 'unexpected error fetching customer record, please check logs' }
+// }
+
+
+// // TODO - this is where we can add additional checks to validate the user
+// // if (new Date(user.created_at).getTime() > Date.now() - MIN_ACCOUNT_AGE) {
+// //   console.error(`account too young: ${user.login}`)
+// //   return { statusCode: 400, body: 'account too young' }
+// // }
+
+// // add a customer with a trial product
+// const customerPutRes = await customerStore.put({
+//   customer,
+//   product: 'did:web:trial.storacha.network',
+//   // TODO: should we add anything humanode specific here?
+//   // details: JSON.stringify({ github: { id: user.id, login: user.login } }),
+//   insertedAt: new Date()
+// })
+// if (!customerPutRes.ok) {
+//   console.error(`putting customer: ${customer}`, customerPutRes.error)
+//   return { statusCode: 500, body: 'failed to put customer' }
+// }
+
+// return {
+//   statusCode: 200,
+//   headers: { 'Content-Type': 'text/html' },
+//   body: Buffer.from(getResponseHTML()).toString('base64'),
+//   isBase64Encoded: true,
+// }
+// }

--- a/upload-api/functions/oauth-humanode-callback.js
+++ b/upload-api/functions/oauth-humanode-callback.js
@@ -10,6 +10,7 @@ import { mustGetEnv } from '../../lib/env.js'
 import { createCustomerStore } from '../../billing/tables/customer.js'
 import { getServiceSigner } from '../config.js'
 import { jwtDecode } from "jwt-decode"
+import { createHumanodesTable } from '../stores/humanodes.js'
 
 
 /**
@@ -23,6 +24,7 @@ import { jwtDecode } from "jwt-decode"
  * @typedef {{
  *   serviceSigner: Signer
  *   customerStore: import('../../billing/lib/api.js').CustomerStore
+ *   humanodeStore: import('../types.js').HumanodeStore
  * }} Context
  */
 
@@ -46,6 +48,7 @@ export const oauthCallbackGet = async (request, context) => {
   const {
     serviceSigner,
     customerStore,
+    humanodeStore
   } = getContext(context?.clientContext?.Custom)
 
   const code = request.queryStringParameters?.code
@@ -69,10 +72,18 @@ export const oauthCallbackGet = async (request, context) => {
   const tokenResult = await tokenResponse.json()
   const humanodeIdToken = jwtDecode(tokenResult.id_token)
   const humanodeId = humanodeIdToken.sub
-  
-  // TODO we need to make sure this humanodeId hasn't been used before
-  // I'm thinking just a dynamo table following our normal patterns
+  if (!humanodeId) {
+    console.error("humanodeId is not undefined, this is very strange")
+    return { statusCode: 500, body: 'failed to get humanode ID' }
+  }
 
+  const existsResponse = await humanodeStore.exists(humanodeId)
+  if (existsResponse.error){
+    return htmlResponse(500, getUnexpectedErrorResponseHTML(existsResponse.error.message))
+  }
+  if (existsResponse.ok){
+    return htmlResponse(400, getDuplicateHumanodeResponseHTML())
+  }
 
   // validate the access/authorize delegation and pull the customer email out of it
   const extractRes = await Delegation.extract(base64url.decode(request.queryStringParameters?.state ?? ''))
@@ -93,8 +104,19 @@ export const oauthCallbackGet = async (request, context) => {
     console.error('validating access/authorize delegation', accessRes.error)
     return { statusCode: 400, body: 'failed to validate access/authorize delegation' }
   }
-  const customer = DidMailto.fromEmail(/** @type {`${string}@${string}`} */(accessRes.ok.capability.nb.iss))
-  
+
+  if (!accessRes.ok.capability.nb.iss) {
+    return { statusCode: 400, body: 'account DID not included in authorize request' }
+  }
+
+  let customer
+  try {
+    customer = DidMailto.fromString(accessRes.ok.capability.nb.iss)
+  } catch (e) {
+    console.error("error parsing did:mailto:", e)
+    return { statusCode: 400, body: 'nb.iss must be a valid did:mailto' }
+  }
+
   // add a customer with a trial product
   const customerPutRes = await customerStore.put({
     customer,
@@ -107,12 +129,9 @@ export const oauthCallbackGet = async (request, context) => {
     return { statusCode: 500, body: 'failed to put customer' }
   }
 
-  return {
-    statusCode: 200,
-    headers: { 'Content-Type': 'text/html' },
-    body: Buffer.from(getResponseHTML()).toString('base64'),
-    isBase64Encoded: true,
-  }
+  await humanodeStore.add(humanodeId)
+
+  return htmlResponse(200, getResponseHTML())
 }
 
 export const handler = Sentry.AWSLambda.wrapHandler((event) => oauthCallbackGet(event))
@@ -132,13 +151,28 @@ const getContext = (customContext) => {
   })
 
   const customerStore = createCustomerStore({ region }, { tableName: mustGetEnv('CUSTOMER_TABLE_NAME') })
-
+  const humanodeStore = createHumanodesTable(region, mustGetEnv('HUMANODE_TABLE_NAME'))
+  
   return {
     serviceSigner,
     customerStore,
+    humanodeStore
   }
 }
 
+/**
+ * @param {number} statusCode
+ * @param {string} body 
+ * @returns 
+ */
+function htmlResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'text/html' },
+    body: Buffer.from(body).toString('base64'),
+    isBase64Encoded: true,
+  }
+}
 
 const getResponseHTML = () => `
 <!doctype html>
@@ -151,6 +185,7 @@ const getResponseHTML = () => `
       <div style="text-align:center">
         <img src="https://w3s.link/ipfs/bafybeihinjwsn3kgjrlpdada4xingozsni3boywlscxspc5knatftauety/storacha-bug.svg" alt="Storacha - Decentralized Hot Storage Layer on Filecoin">
         <h1 style="font-weight:normal">Authorization Successful</h1>
+        <p>You have been granted a free Storacha storage plan.</p>
         <p>You may now close this window.</p>
       </div>
     </div>
@@ -158,169 +193,45 @@ const getResponseHTML = () => `
 </html>
 `.trim()
 
+const getDuplicateHumanodeResponseHTML = () => `
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Authorized - Storacha Network</title>
+  </head>
+  <body style="font-family:sans-serif;color:#000">
+    <div style="height:100vh;display:flex;align-items:center;justify-content:center">
+      <div style="text-align:center">
+        <img src="https://w3s.link/ipfs/bafybeihinjwsn3kgjrlpdada4xingozsni3boywlscxspc5knatftauety/storacha-bug.svg" alt="Storacha - Decentralized Hot Storage Layer on Filecoin">
+        <h1 style="font-weight:normal">Plan Selection Unsuccessful</h1>
+        <p>The identified human has already claimed their free plan.</p>
+        <p>You may now close this window.</p>
+      </div>
+    </div>
+  </body>
+</html>
+`.trim()
 
-
-
-
-// return {
-//   statusCode: 302,
-//   headers: {
-//     Location: "http://localhost:3000"
-//   }
-
-// }
-
-
-// const extractRes = await Delegation.extract(base64url.decode(request.queryStringParameters?.state ?? ''))
-// if (extractRes.error) {
-//   console.error('decoding access/authorize delegation', extractRes.error)
-//   return { statusCode: 400, body: 'failed to decode access/authorize delegation' }
-// }
-
-// const authRequest =
-//   /** @type {import('@ucanto/interface').Invocation<import('@storacha/upload-api').AccessAuthorize>} */
-//   (extractRes.ok)
-
-// const accessRes = await Validator.access(authRequest, {
-//   capability: Access.authorize,
-//   authority: serviceSigner,
-//   principal: Verifier,
-//   validateAuthorization: () => ok({})
-// })
-// if (accessRes.error) {
-//   console.error('validating access/authorize delegation', accessRes.error)
-//   return { statusCode: 400, body: 'failed to validate access/authorize delegation' }
-// }
-
-
-// // const accessTokenRes = await github.getOAuthAccessToken({ code })
-// // if (!accessTokenRes.ok) {
-// //   console.error(accessTokenRes.error)
-// //   return { statusCode: 400, body: 'failed to get OAuth access token' }
-// // }
-// // const accessToken = accessTokenRes.ok.access_token
-
-// // const [userRes, userEmailsRes] = await Promise.all([
-// //   github.getUser({ accessToken }),
-// //   github.getUserEmails({ accessToken })
-// // ])
-// // if (!userRes.ok) {
-// //   console.error(userRes.error)
-// //   return { statusCode: 500, body: 'failed to get user profile' }
-// // }
-// // if (!userEmailsRes.ok) {
-// //   console.error(userEmailsRes.error)
-// //   return { statusCode: 500, body: 'failed to get user emails' }
-// // }
-
-// // const user = userRes.ok
-// // const emails = userEmailsRes.ok
-// // const primary = emails.find(e => e.primary && e.verified)
-// // if (!primary) {
-// //   console.error('missing primary verified email', emails)
-// //   return { statusCode: 400, body: 'missing primary verified email' }
-// // }
-
-// // record the auth request and issue a receipt
-// const lifetimeInSeconds = 60 * 15
-// const message = await Message.build({
-//   invocations: [authRequest],
-//   receipts: [
-//     await Receipt.issue({
-//       issuer: serviceSigner,
-//       ran: authRequest,
-//       result: ok({
-//         expiration: Math.floor(Date.now() / 1000) + lifetimeInSeconds,
-//         request: authRequest.cid
-//       })
-//     })
-//   ]
-// })
-// const messageWriteRes = await agentStore.messages.write({
-//   source: await Transport.outbound.encode(message),
-//   data: message,
-//   index: AgentMessage.index(message)
-// })
-// if (messageWriteRes.error) {
-//   console.error(messageWriteRes.error)
-//   return { statusCode: 500, body: 'failed to write access/authorize invocation and receipt' }
-// }
-
-// // pull the email address out of access/authorize
-// const customer = DidMailto.fromEmail(/** @type {`${string}@${string}`} */(accessRes.ok.capability.nb.iss))
-
-// // this can be set to true later on if we get enough signal to trust that this email is really the person it claims to be (like we do with github verified emails)
-// const shouldWeConfirm = false
-// if (shouldWeConfirm) {
-//   const confirmRes = await Access.confirm
-//     .invoke({
-//       issuer: serviceSigner,
-//       // audience same as issuer because this is a service invocation
-//       audience: serviceSigner,
-//       // Because with is set to our DID no other actor will be able to issue
-//       // this delegation without our private key.
-//       with: serviceSigner.did(),
-//       lifetimeInSeconds,
-//       // We link to the authorization request so that this attestation can
-//       // not be used to authorize a different request.
-//       nb: {
-//         // we copy request details and set the `aud` field to the agent DID
-//         // that requested the authorization.
-//         iss: customer,
-//         att: authRequest.capabilities[0].nb.att,
-//         aud: authRequest.capabilities[0].with,
-//         // Link to the invocation that requested the authorization.
-//         cause: authRequest.cid,
-//       },
-//     })
-//     .execute(getServiceConnection())
-
-//   if (!confirmRes.out.ok) {
-//     console.error('executing access/confirm', confirmRes.out.error)
-//     return { statusCode: 500, body: 'failed to execute access/confirm invocation' }
-//   }
-// }
-
-
-// const customerGetRes = await customerStore.get({ customer })
-// if (customerGetRes.ok) {
-//   return {
-//     statusCode: 200,
-//     headers: { 'Content-Type': 'text/html' },
-//     body: Buffer.from(getResponseHTML()).toString('base64'),
-//     isBase64Encoded: true,
-//   }
-// }
-
-// if (customerGetRes.error.name !== 'RecordNotFound') {
-//   console.error(`getting customer: ${customer}`, customerGetRes.error)
-//   return { statusCode: 500, body: 'unexpected error fetching customer record, please check logs' }
-// }
-
-
-// // TODO - this is where we can add additional checks to validate the user
-// // if (new Date(user.created_at).getTime() > Date.now() - MIN_ACCOUNT_AGE) {
-// //   console.error(`account too young: ${user.login}`)
-// //   return { statusCode: 400, body: 'account too young' }
-// // }
-
-// // add a customer with a trial product
-// const customerPutRes = await customerStore.put({
-//   customer,
-//   product: 'did:web:trial.storacha.network',
-//   // TODO: should we add anything humanode specific here?
-//   // details: JSON.stringify({ github: { id: user.id, login: user.login } }),
-//   insertedAt: new Date()
-// })
-// if (!customerPutRes.ok) {
-//   console.error(`putting customer: ${customer}`, customerPutRes.error)
-//   return { statusCode: 500, body: 'failed to put customer' }
-// }
-
-// return {
-//   statusCode: 200,
-//   headers: { 'Content-Type': 'text/html' },
-//   body: Buffer.from(getResponseHTML()).toString('base64'),
-//   isBase64Encoded: true,
-// }
-// }
+/**
+ * 
+ * @param {string} message 
+ * @returns 
+ */
+const getUnexpectedErrorResponseHTML = (message) => `
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Authorized - Storacha Network</title>
+  </head>
+  <body style="font-family:sans-serif;color:#000">
+    <div style="height:100vh;display:flex;align-items:center;justify-content:center">
+      <div style="text-align:center">
+        <img src="https://w3s.link/ipfs/bafybeihinjwsn3kgjrlpdada4xingozsni3boywlscxspc5knatftauety/storacha-bug.svg" alt="Storacha - Decentralized Hot Storage Layer on Filecoin">
+        <h1 style="font-weight:normal">Unexpected Error</h1>
+        <p>An unexpected error occured while trying to authenticate you: ${message} </p>
+        <p>Please close this window and try again.</p>
+      </div>
+    </div>
+  </body>
+</html>
+`.trim()

--- a/upload-api/stores/humanodes.js
+++ b/upload-api/stores/humanodes.js
@@ -1,0 +1,81 @@
+import {
+  GetItemCommand,
+  PutItemCommand,
+} from '@aws-sdk/client-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
+
+/**
+ * Abstraction layer to handle operations on humanodes table.
+ *
+ * @param {string} region
+ * @param {string} tableName
+ * @param {object} [options]
+ * @param {string} [options.endpoint]
+ */
+export function createHumanodesTable(region, tableName, options = {}) {
+  const dynamoDb = getDynamoClient({
+    region,
+    endpoint: options.endpoint,
+  })
+
+  return useHumanodesTable(dynamoDb, tableName)
+}
+
+/**
+ * A table to track Humanode IDs.
+ * 
+ * Humanode has a facial hashing system that gives tells us whether we've
+ * seen a particular face before. This table tracks whether we've seen
+ * a specific face hash.
+ * 
+ * We use the name `sub` for the face hash because that is the name it
+ * is given in the JWT we receive it in - it's short for `subject`.
+ * 
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
+ * @param {string} tableName
+ * @returns {import('../types.ts').HumanodeStore}
+ */
+export function useHumanodesTable(dynamoDb, tableName) {
+  return {
+    async add(sub) {
+      try {
+        await dynamoDb.send(new PutItemCommand({
+          TableName: tableName,
+          Item: marshall({
+            sub
+          }),
+        }))
+        return { ok: {} }
+      } catch (/** @type {any} */err) {
+        return {
+          error: {
+            name: 'UnexpectedError',
+            message: err.message,
+            cause: err
+          }
+        }
+      }
+    },
+
+    async exists(sub) {
+      try {
+        const result = await dynamoDb.send(new GetItemCommand({
+          TableName: tableName,
+          Key: marshall({
+            sub
+          })
+        }))
+        return { ok: Boolean(result.Item) }
+      } catch (/** @type {any} */err) {
+        return {
+          error: {
+            name: 'UnexpectedError',
+            message: err.message,
+            cause: err
+          }
+        }
+      }
+    }
+  }
+}

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -158,6 +158,18 @@ export const revocationTableProps = {
   primaryIndex: { partitionKey: 'revoke'}
 }
 
+/**
+ * 
+ * @type TableProps 
+ */
+export const humanodeTableProps = {
+  fields: {
+    // the humanode "subject" - `sub` matches the name it is given in the JWT we receive.
+    sub: 'string',
+  },
+  primaryIndex: { partitionKey: 'sub'}
+}
+
 /** @type TableProps */
 export const adminMetricsTableProps = {
   fields: {

--- a/upload-api/types.ts
+++ b/upload-api/types.ts
@@ -253,6 +253,9 @@ declare module 'sst/node/config' {
     GITHUB_CLIENT_SECRET: {
       value: string
     },
+    HUMANODE_CLIENT_SECRET: {
+      value: string
+    },
     INDEXING_SERVICE_PROOF: {
       value: string
     }

--- a/upload-api/types.ts
+++ b/upload-api/types.ts
@@ -3,7 +3,7 @@ import { DID, Delegation, UCANLink, ByteView, DIDKey, Result, Failure, Unit } fr
 import { UnknownLink } from 'multiformats'
 import { CID } from 'multiformats/cid'
 import { CarStoreBucket } from '@web3-storage/upload-api'
-import { AccountDID, ProviderDID, Service, SpaceDID, PlanCreateAdminSessionSuccess, PlanCreateAdminSessionFailure, AgentStore } from '@storacha/upload-api'
+import { AccountDID, ProviderDID, Service, SpaceDID, PlanCreateAdminSessionSuccess, PlanCreateAdminSessionFailure, AgentStore, UnexpectedError } from '@storacha/upload-api'
 
 export type {
   UnknownLink,
@@ -286,4 +286,10 @@ export interface ReferralsStore {
   getReferredBy: (email: string) => Promise<Referral>
 }
 
+export interface HumanodeStore {
+  add: (sub: string) => Promise<Result<Unit, UnexpectedError>>
+  exists: (sub: string) => Promise<Result<boolean, UnexpectedError>>
+}
+
 export {}
+


### PR DESCRIPTION
Add a Humanode OAuth callback that will give a "free storage with no credit card" plan to a user who uses Humanode to prove they are a unique person.

<img width="1220" alt="Screenshot 2025-04-10 at 3 42 22 PM" src="https://github.com/user-attachments/assets/3ae37e80-dd0c-4348-8ad2-1761ce4213cb" />
<img width="1220" alt="Screenshot 2025-04-10 at 3 43 09 PM" src="https://github.com/user-attachments/assets/dddcc6da-2863-465f-9c1c-808f40a172e1" />
<img width="1225" alt="Screenshot 2025-04-10 at 3 44 11 PM" src="https://github.com/user-attachments/assets/30f13cd5-4c52-4858-84ad-738d9b658c6d" />
<img width="1220" alt="Screenshot 2025-04-10 at 3 43 19 PM" src="https://github.com/user-attachments/assets/b56609c3-ea21-4e15-a09a-12c3f9c71a95" />

The one remaining concern I have with this code is the duplication in the templates - we now have 4 blobs of HTML like this across the two OAuth handlers and I'm not sure the best way to consolidate - any thoughts @alanshaw ?