### PR TITLE
feat(agentstore): put index in dynamo

### DIFF
--- a/filecoin/functions/handle-cron-tick.js
+++ b/filecoin/functions/handle-cron-tick.js
@@ -20,7 +20,7 @@ Sentry.AWSLambda.init({
 const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
 
 export async function handleCronTick () {
-  const { did, pieceTableName, agentMessageBucketName, agentIndexBucketName, aggregatorDid, storefrontProof } = getEnv()
+  const { did, pieceTableName, agentMessageBucketName, agentIndexBucketName, agentIndexTableName, aggregatorDid, storefrontProof } = getEnv()
   const { PRIVATE_KEY: privateKey } = Config
 
   // create context
@@ -40,8 +40,8 @@ export async function handleCronTick () {
   const context = {
     id,
     pieceStore: createPieceTable(AWS_REGION, pieceTableName),
-    taskStore: createTaskStore(AWS_REGION, agentIndexBucketName, agentMessageBucketName),
-    receiptStore: createReceiptStore(AWS_REGION, agentIndexBucketName, agentMessageBucketName),
+    taskStore: createTaskStore(AWS_REGION, agentIndexTableName, agentIndexBucketName, agentMessageBucketName),
+    receiptStore: createReceiptStore(AWS_REGION, agentIndexTableName, agentIndexBucketName, agentMessageBucketName),
     aggregatorId: DID.parse(aggregatorDid),
   }
 
@@ -66,6 +66,7 @@ function getEnv () {
     pieceTableName: mustGetEnv('PIECE_TABLE_NAME'),
     agentMessageBucketName: mustGetEnv('AGENT_MESSAGE_BUCKET_NAME'),
     agentIndexBucketName: mustGetEnv('AGENT_INDEX_BUCKET_NAME'),
+    agentIndexTableName: mustGetEnv('AGENT_INDEX_TABLE_NAME'),
     aggregatorDid: mustGetEnv('AGGREGATOR_DID'),
     storefrontProof: process.env.PROOF,
   }

--- a/filecoin/functions/metrics-aggregate-offer-and-accept-total.js
+++ b/filecoin/functions/metrics-aggregate-offer-and-accept-total.js
@@ -25,12 +25,13 @@ async function handler(event) {
     metricsTableName,
     agentMessageBucketName,
     agentIndexBucketName,
+    agentIndexTableName,
     startEpochMs
   } = getLambdaEnv()
 
   const filecoinMetricsStore = createFilecoinMetricsTable(AWS_REGION, metricsTableName)
   const workflowStore = createWorkflowStore(AWS_REGION, agentMessageBucketName)
-  const invocationStore = createInvocationStore(AWS_REGION, agentIndexBucketName)
+  const invocationStore = createInvocationStore(AWS_REGION, agentIndexBucketName, agentIndexTableName)
 
   await Promise.all([
     updateAggregateOfferTotal(ucanInvocations, {

--- a/filecoin/store/invocation.js
+++ b/filecoin/store/invocation.js
@@ -1,35 +1,51 @@
 import { parseLink } from '@ucanto/core'
 import * as Store from '../../upload-api/stores/agent/store.js'
 import { getS3Client } from '../../lib/aws/s3.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
  * invocation receipts and indexes.
  *
  * @param {string} region
+ * @param {string} tableName
  * @param {string} bucketName
- * @param {Partial<import('../../lib/aws/s3.js').Address>} [options]
+ * @param {{
+ *   s3Address?: Partial<import('../../lib/aws/s3.js').Address>
+ *   dynamoAddress?: Partial<import('../../lib/aws/dynamo.js').Address>
+ * }} [options]
  */
-export function createInvocationStore(region, bucketName, options = {}) {
+export function createInvocationStore(region, tableName,  bucketName, options = {}) {
+  const dynamoDBClient = getDynamoClient({
+    region,
+    ...options.dynamoAddress,
+  })
   const s3client = getS3Client({
     region,
-    ...options,
+    ...options.s3Address,
   })
-  return useInvocationStore(s3client, bucketName)
+
+  return useInvocationStore(dynamoDBClient, s3client, tableName, bucketName)
 }
 
 /**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDBClient
  * @param {import('@aws-sdk/client-s3').S3Client} s3client
+ * @param {string} tableName
  * @param {string} bucketName
  * @returns {import('../types.js').InvocationBucket}
  */
-export const useInvocationStore = (s3client, bucketName) => {
+export const useInvocationStore = (dynamoDBClient, s3client, tableName, bucketName) => {
   const store = Store.open({
-    connection: { channel: s3client },
+    s3Connection: { channel: s3client },
+    dynamoDBConnection: { channel: dynamoDBClient },
     region: typeof s3client.config.region === 'string' ? s3client.config.region : 'us-west-2',
     buckets: {
       index: { name: bucketName },
       message: { name: bucketName },
+    },
+    tables: {
+      index: { name: tableName }
     }
   })
 

--- a/filecoin/store/task.js
+++ b/filecoin/store/task.js
@@ -1,37 +1,52 @@
 import { StoreOperationFailed } from '@storacha/filecoin-api/errors'
 import * as Store from '../../upload-api/stores/agent/store.js'
 import { getS3Client } from '../../lib/aws/s3.js'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket storing
  * handled Tasks and their indexes.
  *
  * @param {string} region
+ * @param {string} agentIndexTableName
  * @param {string} agentIndexBucketName
  * @param {string} agentMessageBucketName
- * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
+ * @param {{
+*   s3Address?: Partial<import('../../lib/aws/s3.js').Address>
+*   dynamoAddress?: Partial<import('../../lib/aws/dynamo.js').Address>
+* }} [options]
  */
-export function createTaskStore(region, agentIndexBucketName, agentMessageBucketName, options = {}) {
+export function createTaskStore(region, agentIndexTableName, agentIndexBucketName, agentMessageBucketName, options = {}) {
+  const dynamoDBClient = getDynamoClient({
+    region,
+    ...options.dynamoAddress,
+  })
   const s3client = getS3Client({
     region,
     ...options,
   })
-  return useTaskStore(s3client, agentIndexBucketName, agentMessageBucketName)
+  return useTaskStore(dynamoDBClient, s3client, agentIndexTableName, agentIndexBucketName, agentMessageBucketName)
 }
 
 /**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDBClient
  * @param {import('@aws-sdk/client-s3').S3Client} s3client
+ * @param {string} agentIndexTableName
  * @param {string} agentIndexBucketName
  * @param {string} agentMessageBucketName
  * @returns {import('@storacha/filecoin-api/storefront/api').TaskStore}
  */
-export const useTaskStore = (s3client, agentIndexBucketName, agentMessageBucketName) => {
+export const useTaskStore = (dynamoDBClient, s3client, agentIndexTableName, agentIndexBucketName, agentMessageBucketName) => {
   const store = Store.open({
-    connection: { channel: s3client },
+    dynamoDBConnection: { channel: dynamoDBClient },
+    s3Connection: { channel: s3client },
     region: typeof s3client.config.region === 'string' ? s3client.config.region : 'us-west-2',
     buckets: {
       index: { name: agentIndexBucketName },
       message: { name: agentMessageBucketName },
+    },
+    tables: {
+      index: { name: agentIndexTableName }
     }
   })
 

--- a/filecoin/test/helpers/context.js
+++ b/filecoin/test/helpers/context.js
@@ -13,6 +13,7 @@ import anyTest from 'ava'
  * @typedef {object} DynamoContext
  * @property {string} dbEndpoint
  * @property {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient
+ * @property {import('../../../lib/aws/dynamo.js').Address} dynamoOpts
  * 
  * @typedef {object} MultipleQueueContext
  * @property {import('@aws-sdk/client-sqs').SQSClient} sqsClient

--- a/filecoin/test/helpers/resources.js
+++ b/filecoin/test/helpers/resources.js
@@ -24,6 +24,7 @@ export async function createDynamodDb(opts = {}) {
       region,
       endpoint
     }),
+    region,
     endpoint,
     stop: () => dbContainer.stop(),
   }

--- a/filecoin/test/metrics-aggregate-accept-total.test.js
+++ b/filecoin/test/metrics-aggregate-accept-total.test.js
@@ -33,11 +33,12 @@ test.before(async t => {
   // Dynamo DB
   const {
     client: dynamo,
+    region,
     endpoint: dbEndpoint
   } = await createDynamodDb({ port: 8000 })
   t.context.dbEndpoint = dbEndpoint
   t.context.dynamoClient = dynamo
-
+  t.context.dynamoOpts = { region, endpoint: dbEndpoint}
   // S3
   const { client, clientOpts } = await createS3()
   t.context.s3Client = client

--- a/lib/aws/dynamo.js
+++ b/lib/aws/dynamo.js
@@ -1,9 +1,13 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 
+/**
+ * @typedef {{ region: string, endpoint?: string }} Address
+ */
+
 /** @type {Record<string, import('@aws-sdk/client-dynamodb').DynamoDBClient>} */
 const dynamoClients = {}
 
-/** @param {{ region: string, endpoint?: string }} config */
+/** @param {Address} config */
 export function getDynamoClient (config) {
   const key = `${config.region}#${config.endpoint ?? 'default'}`
   if (!dynamoClients[key]) {

--- a/stacks/filecoin-stack.js
+++ b/stacks/filecoin-stack.js
@@ -42,7 +42,7 @@ export function FilecoinStack({ stack, app }) {
   // Get store table reference
   const { pieceTable, privateKey, adminMetricsTable, indexingServiceProof } = use(UploadDbStack)
   // Get UCAN store references
-  const { agentMessageBucket, agentIndexBucket, ucanStream } = use(UcanInvocationStack)
+  const { agentIndexTable, agentMessageBucket, agentIndexBucket, ucanStream } = use(UcanInvocationStack)
   const { roundaboutApiUrl } = use(RoundaboutStack)
 
   /**
@@ -122,6 +122,7 @@ export function FilecoinStack({ stack, app }) {
         environment : {
           DID: STOREFRONT_PROOF ? UPLOAD_API_DID : AGGREGATOR_DID,
           PIECE_TABLE_NAME: pieceTable.tableName,
+          AGENT_INDEX_TABLE_NAME: agentIndexTable.tableName,
           AGENT_MESSAGE_BUCKET_NAME: agentMessageBucket.bucketName,
           AGENT_INDEX_BUCKET_NAME: agentIndexBucket.bucketName,
           AGGREGATOR_DID,
@@ -129,7 +130,7 @@ export function FilecoinStack({ stack, app }) {
         },
         timeout: '6 minutes',
         bind: [privateKey],
-        permissions: [pieceTable, agentMessageBucket, agentIndexBucket],
+        permissions: [pieceTable, agentIndexTable, agentMessageBucket, agentIndexBucket],
       }
     }
   })
@@ -307,11 +308,12 @@ export function FilecoinStack({ stack, app }) {
   const metricsAggregateTotalConsumer = new Function(stack, 'metrics-aggregate-total-consumer', {
     environment: {
       METRICS_TABLE_NAME: adminMetricsTable.tableName,
+      AGENT_INDEX_TABLE_NAME: agentIndexTable.tableName,
       AGENT_MESSAGE_BUCKET_NAME: agentMessageBucket.bucketName,
       AGENT_INDEX_BUCKET_NAME: agentIndexBucket.bucketName,
       START_FILECOIN_METRICS_EPOCH_MS
     },
-    permissions: [adminMetricsTable, agentMessageBucket, agentIndexBucket],
+    permissions: [adminMetricsTable, agentIndexTable, agentMessageBucket, agentIndexBucket],
     handler: 'filecoin/functions/metrics-aggregate-offer-and-accept-total.consumer',
     deadLetterQueue: metricsAggregateTotalDLQ.cdk.queue,
     timeout: 3 * 60,

--- a/stacks/ucan-invocation-stack.js
+++ b/stacks/ucan-invocation-stack.js
@@ -1,6 +1,7 @@
 import {
   Bucket,
   KinesisStream,
+  Table,
 } from 'sst/constructs'
 import { PolicyStatement, StarPrincipal, Effect } from 'aws-cdk-lib/aws-iam'
 
@@ -9,6 +10,7 @@ import {
   getKinesisStreamConfig,
   setupSentry
 } from './config.js'
+import { agentIndexTableProps } from '../upload-api/tables/index.js'
 
 /**
  * @param {import('sst/constructs').StackContext} properties
@@ -41,13 +43,15 @@ export function UcanInvocationStack({ stack, app }) {
       resources: [agentMessageBucket.cdk.bucket.arnForObjects('*')],
     })
   )
-
+  
   const agentIndexBucket = new Bucket(stack, 'invocation-store', {
     cors: true,
     cdk: {
       bucket: getBucketConfig('invocation-store', app.stage)
     }
   })
+
+  const agentIndexTable = new Table(stack, 'invocation-table', agentIndexTableProps)
 
   // TODO: keep for historical content that we might want to process
   new Bucket(stack, 'ucan-store', {
@@ -80,6 +84,7 @@ export function UcanInvocationStack({ stack, app }) {
   })
 
   return {
+    agentIndexTable,
     agentIndexBucket,
     agentMessageBucket,
     ucanStream

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -44,7 +44,7 @@ export function UploadApiStack({ stack, app }) {
   // Get references to constructs created in other stacks
   const { carparkBucket } = use(CarparkStack)
   const { allocationTable, blobRegistryTable, humanodeTable, storeTable, uploadTable, delegationBucket, delegationTable, revocationTable, adminMetricsTable, spaceMetricsTable, consumerTable, subscriptionTable, storageProviderTable, rateLimitTable, pieceTable, privateKey, indexingServiceProof, githubClientSecret, humanodeClientSecret } = use(UploadDbStack)
-  const { agentIndexBucket, agentMessageBucket, ucanStream } = use(UcanInvocationStack)
+  const { agentIndexTable, agentIndexBucket, agentMessageBucket, ucanStream } = use(UcanInvocationStack)
   const { customerTable, spaceDiffTable, spaceSnapshotTable, egressTrafficTable, stripeSecretKey } = use(BillingDbStack)
   const { pieceOfferQueue, filecoinSubmitQueue } = use(FilecoinStack)
   const { blockAdvertPublisherQueue } = use(IndexerStack)
@@ -88,6 +88,7 @@ export function UploadApiStack({ stack, app }) {
             storageProviderTable,
             egressTrafficTable,
             carparkBucket,
+            agentIndexTable,
             agentIndexBucket,
             agentMessageBucket,
             ucanStream,
@@ -117,6 +118,7 @@ export function UploadApiStack({ stack, app }) {
             SPACE_SNAPSHOT_TABLE_NAME: spaceSnapshotTable.tableName,
             STORAGE_PROVIDER_TABLE_NAME: storageProviderTable.tableName,
             DELEGATION_BUCKET_NAME: delegationBucket.bucketName,
+            AGENT_INDEX_TABLE_NAME: agentIndexTable.tableName,
             AGENT_INDEX_BUCKET_NAME: agentIndexBucket.bucketName,
             AGENT_MESSAGE_BUCKET_NAME: agentMessageBucket.bucketName,
             UCAN_LOG_STREAM_NAME: ucanStream.streamName,

--- a/upload-api/functions/oauth-callback.js
+++ b/upload-api/functions/oauth-callback.js
@@ -220,11 +220,15 @@ const getContext = (customContext) => {
 
   const agentStore = openAgentStore({
     store: {
-      connection: { address: { region } },
+      dynamoDBConnection: { address: { region } },
+      s3Connection: { address: { region } },
       region,
       buckets: {
         message: { name: mustGetEnv('WORKFLOW_BUCKET_NAME') },
         index: { name: mustGetEnv('INVOCATION_BUCKET_NAME') },
+      },
+      tables: {
+        index: { name: mustGetEnv('INVOCATION_TABLE_NAME') },
       },
     },
     stream: {

--- a/upload-api/functions/receipt.js
+++ b/upload-api/functions/receipt.js
@@ -54,11 +54,15 @@ export async function receiptGet (event, options = implicitContext()) {
 export function implicitContext () {
   const region = process.env.AWS_REGION || 'us-west-2'
   return {
-    connection: { address: { region } },
+    dynamoDBConnection: { address: { region } },
+    s3Connection: { address: { region } },
     region,
     buckets: {
       index: { name: mustGetEnv('AGENT_INDEX_BUCKET_NAME') },
       message: { name: mustGetEnv('AGENT_MESSAGE_BUCKET_NAME') },
+    },
+    tables: {
+      index: { name: mustGetEnv('AGENT_INDEX_TABLE_NAME') }
     }
   }
 }

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -140,6 +140,7 @@ export async function ucanInvocationRouter(request) {
     r2DelegationBucketAccessKeyId,
     r2DelegationBucketSecretAccessKey,
     r2DelegationBucketName,
+    agentIndexTableName,
     agentIndexBucketName,
     agentMessageBucketName,
     streamName,
@@ -182,7 +183,12 @@ export async function ucanInvocationRouter(request) {
 
   const agentStore = AgentStore.open({
     store: {
-      connection: {
+      dynamoDBConnection: {
+        address: {
+          region: AWS_REGION
+        }
+      },
+      s3Connection: {
         address: {
           region: AWS_REGION
         },
@@ -192,6 +198,9 @@ export async function ucanInvocationRouter(request) {
         message: { name: agentMessageBucketName },
         index: { name: agentIndexBucketName },
       },
+      tables: {
+        index: { name: agentIndexTableName }
+      }
     },
     stream: {
       connection: { address: {} },
@@ -328,8 +337,8 @@ export async function ucanInvocationRouter(request) {
     rateLimitsStorage,
     aggregatorId: DID.parse(aggregatorDid),
     pieceStore: createPieceTable(AWS_REGION, pieceTableName),
-    taskStore: createFilecoinTaskStore(AWS_REGION, agentIndexBucketName, agentMessageBucketName),
-    receiptStore: createFilecoinReceiptStore(AWS_REGION, agentIndexBucketName, agentMessageBucketName),
+    taskStore: createFilecoinTaskStore(AWS_REGION, agentIndexTableName, agentIndexBucketName, agentMessageBucketName),
+    receiptStore: createFilecoinReceiptStore(AWS_REGION, agentIndexTableName, agentIndexBucketName, agentMessageBucketName),
     pieceOfferQueue: createPieceOfferQueueClient({ region: AWS_REGION }, { queueUrl: pieceOfferQueueUrl }),
     filecoinSubmitQueue: createFilecoinSubmitQueueClient({ region: AWS_REGION }, { queueUrl: filecoinSubmitQueueUrl }),
     dealTrackerService: {
@@ -406,6 +415,7 @@ function getLambdaEnv () {
     r2DelegationBucketAccessKeyId: mustGetEnv('R2_ACCESS_KEY_ID'),
     r2DelegationBucketSecretAccessKey: mustGetEnv('R2_SECRET_ACCESS_KEY'),
     r2DelegationBucketName: mustGetEnv('R2_DELEGATION_BUCKET_NAME'),
+    agentIndexTableName: mustGetEnv('AGENT_INDEX_TABLE_NAME'),
     agentIndexBucketName: mustGetEnv('AGENT_INDEX_BUCKET_NAME'),
     agentMessageBucketName: mustGetEnv('AGENT_MESSAGE_BUCKET_NAME'),
     streamName: mustGetEnv('UCAN_LOG_STREAM_NAME'),

--- a/upload-api/functions/ucan.js
+++ b/upload-api/functions/ucan.js
@@ -22,6 +22,7 @@ const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
 async function handlerFn(request) {
   const {
     AGENT_INDEX_BUCKET_NAME: agentIndexBucketName = '',
+    AGENT_INDEX_TABLE_NAME: agentIndexTableName = '',
     AGENT_MESSAGE_BUCKET_NAME: agentMessageBucketName = '',
     UCAN_LOG_STREAM_NAME: streamName = '',
   } = process.env
@@ -30,7 +31,12 @@ async function handlerFn(request) {
 
   const agentStore = AgentStore.open({
     store: {
-      connection: {
+      dynamoDBConnection: {
+        address: {
+          region: AWS_REGION
+        },
+      },
+      s3Connection: {
         address: {
           region: AWS_REGION
         },
@@ -40,6 +46,9 @@ async function handlerFn(request) {
         message: { name: agentMessageBucketName },
         index: { name: agentIndexBucketName },
       },
+      tables: {
+        index: { name: agentIndexTableName }
+      }
     },
     stream: {
       connection: { address: {} },

--- a/upload-api/functions/validate-email.jsx
+++ b/upload-api/functions/validate-email.jsx
@@ -82,6 +82,7 @@ function createAuthorizeContext() {
     R2_ACCESS_KEY_ID = '',
     R2_SECRET_ACCESS_KEY = '',
     R2_DELEGATION_BUCKET_NAME = '',
+    AGENT_INDEX_TABLE_NAME = '',
     AGENT_INDEX_BUCKET_NAME = '',
     AGENT_MESSAGE_BUCKET_NAME = '',
     POSTMARK_TOKEN = '',
@@ -129,7 +130,12 @@ function createAuthorizeContext() {
 
   const agentStore = AgentStore.open({
     store: {
-      connection: {
+      dynamoDBConnection: {
+        address: {
+          region: AWS_REGION,
+        },
+      },
+      s3Connection: {
         address: {
           region: AWS_REGION,
         },
@@ -139,6 +145,9 @@ function createAuthorizeContext() {
         message: { name: AGENT_MESSAGE_BUCKET_NAME },
         index: { name: AGENT_INDEX_BUCKET_NAME },
       },
+      tables: {
+        index: { name: AGENT_INDEX_TABLE_NAME}
+      }
     },
     stream: {
       connection: { address: {} },

--- a/upload-api/stores/agent/stream.js
+++ b/upload-api/stores/agent/stream.js
@@ -50,9 +50,9 @@ export const open = ({ connection, name, ...settings }) => ({
 
 /**
  *
- * @param {object} connection
- * @param {Store.Store} connection.store
- * @param {Stream} connection.stream
+ * @param {object} s3Connection
+ * @param {Store.Store} s3Connection.store
+ * @param {Stream} s3Connection.stream
  * @param {API.ParsedAgentMessage} message
  * @returns {Promise<API.Result<API.Unit, Error>>}
  */

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -220,3 +220,15 @@ export const storageProviderTableProps = {
   },
   primaryIndex: { partitionKey: 'provider' }
 }
+
+
+/** @type TableProps */
+export const agentIndexTableProps = {
+  fields: {
+    task: 'string',
+    kind: 'string',
+    invocation: 'string',
+    message: 'string',
+  },
+  primaryIndex: { partitionKey: 'task', sortKey: 'kind' }
+}

--- a/upload-api/test/helpers/context.js
+++ b/upload-api/test/helpers/context.js
@@ -24,12 +24,16 @@ import anyTest from 'ava'
  * @typedef {import("ava").TestFn<DynamoContext & S3Context & R2Context & SQSContext & ServiceContext>} Test
  * @typedef {import("ava").TestFn<DynamoContext>} TestDynamo
  * @typedef {import("ava").TestFn<S3Context>} TestS3
+ * @typedef {import("ava").TestFn<S3Context & DynamoContext>} TestS3Dynamo
  * @typedef {import("ava").TestFn<DynamoContext & GetMetricsContext>} TestGetMetrics
  * @typedef {import("ava").TestFn<ServiceContext>} TestService
  */
 
 // eslint-disable-next-line unicorn/prefer-export-from
 export const s3 = /** @type {TestS3} */ (anyTest)
+
+// eslint-disable-next-line unicorn/prefer-export-from
+export const s3Dynamo = /** @type {TestS3Dynamo} */ (anyTest)
 
 // eslint-disable-next-line unicorn/prefer-export-from
 export const dynamo = /** @type {TestDynamo} */ (anyTest)

--- a/upload-api/test/helpers/ucan.js
+++ b/upload-api/test/helpers/ucan.js
@@ -8,7 +8,7 @@ import { DebugEmail } from '@storacha/upload-api/test'
 import { confirmConfirmationUrl } from '@storacha/upload-api/test/utils'
 import { ClaimsService } from '@storacha/upload-api/test/external-service'
 import { createBucket, createTable } from '../helpers/resources.js'
-import { storeTableProps, uploadTableProps, allocationTableProps, consumerTableProps, delegationTableProps, subscriptionTableProps, rateLimitTableProps, revocationTableProps, spaceMetricsTableProps, storageProviderTableProps, blobRegistryTableProps, adminMetricsTableProps } from '../../tables/index.js'
+import { storeTableProps, uploadTableProps, allocationTableProps, consumerTableProps, delegationTableProps, subscriptionTableProps, rateLimitTableProps, revocationTableProps, spaceMetricsTableProps, storageProviderTableProps, blobRegistryTableProps, adminMetricsTableProps, agentIndexTableProps } from '../../tables/index.js'
 import { useBlobRegistry, useAllocationTableBlobRegistry } from '../../stores/blob-registry.js'
 import { composeCarStoresWithOrderedHas } from '../../buckets/car-store.js'
 import { composeBlobStoragesWithOrderedHas } from '../../stores/blobs.js'
@@ -41,6 +41,7 @@ import { create as createIndexingServiceClient } from './external-services/index
 import { createTestIPNIService } from './external-services/ipni-service.js'
 import { useStorageProviderTable } from '../../tables/storage-provider.js'
 import { spaceDiffTableProps } from '../../../billing/tables/space-diff.js'
+import { createDynamoTable } from '../../../filecoin/test/helpers/tables.js'
 
 export { API }
 
@@ -223,15 +224,20 @@ export async function executionContextToUcantoTestServerContext(t) {
   const delegationsBucketName = await createBucket(s3)
   const agentIndexBucketName = await createBucket(s3)
   const agentMessageBucketName = await createBucket(s3)
+  const agentIndexTableName = await createDynamoTable(dynamo, agentIndexTableProps)
 
   const agentStore = AgentStore.open({
     store: {
-      connection: { channel: s3 },
+      dynamoDBConnection: { channel: dynamo },
+      s3Connection: { channel: s3 },
       region: 'us-west-2',
       buckets: {
         message: { name: agentMessageBucketName },
         index: { name: agentIndexBucketName },
       },
+      tables: {
+        index: { name: agentIndexTableName }
+      }
     },
     stream: {
       connection: { disable: {} },
@@ -384,8 +390,8 @@ export async function executionContextToUcantoTestServerContext(t) {
     // filecoin/*
     aggregatorId: aggregatorSigner,
     pieceStore,
-    taskStore: createFilecoinTaskStore('us-west-2', agentIndexBucketName, agentMessageBucketName),
-    receiptStore: createFilecoinReceiptStore('us-west-2', agentIndexBucketName, agentMessageBucketName),
+    taskStore: createFilecoinTaskStore('us-west-2', agentIndexTableName, agentIndexBucketName, agentMessageBucketName),
+    receiptStore: createFilecoinReceiptStore('us-west-2', agentIndexTableName, agentIndexBucketName, agentMessageBucketName),
     // @ts-expect-error not tested here
     pieceOfferQueue: {},
     // @ts-expect-error not tested here

--- a/upload-api/test/route/receipt.js
+++ b/upload-api/test/route/receipt.js
@@ -33,7 +33,7 @@ export const test = {
         taskCid: log.link().toString()
       }
     }, {
-      connection: { channel: context.s3.channel },
+      s3Connection: { channel: context.s3.channel },
       region: `${context.s3.region}`,
       buckets: context.buckets
     })


### PR DESCRIPTION
# Goals

I'm not sure why the agent store was setup to use S3 keys as an index of invocations, but the net effect is we end up using a ListObjectsV2 operation, which is a tier 1 op (see private note additional context)

Proposed approach to resolving this issue is:
1. Get upload service deployed to prod before anything
2. Test and merge this PR and through to prod
3. Write a script to move over all the old keys from S3 to Dynamo
4. Once complete, delete the fallback to S3, to remove ListObject operations (among other things, this is called on every single ucan invocation to check for a cached receipt that is usually empty)

# Implementation

- Add a dynamo table to replace the usage of S3 to manage an index of messages by invocation/receipt - folds into existing operations with minimal changes for now
- Convert many references to the agent store to use this dynamo reference.