### PR TITLE
feat: add `GET /.well-known/did.json` route

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ Also enables the service to accept attestations issued by these DIDs.
 
 Note: should not include UPLOAD_API_DID.
 
+#### `UPLOAD_API_DEPRECATED_DIDS`
+
+Optional CSV list of DIDs (`did:key`) that the upload API used to use. Referenced in the DID document so that UCANs signed with older keys are still considered valid.
+
 #### `R2_ACCESS_KEY_ID`
 
 Access key for S3 like cloud object storage to replicate content into.

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -175,6 +175,7 @@ export function UploadApiStack({ stack, app }) {
         'POST /validate-email': 'upload-api/functions/validate-email.validateEmail',
         'GET /error':   'upload-api/functions/get.error',
         'GET /version': 'upload-api/functions/get.version',
+        'GET /.well-known/did.json': 'upload-api/functions/get.didDocument',
         'GET /metrics': 'upload-api/functions/metrics.handler',
         'GET /receipt/{taskCid}': 'upload-api/functions/receipt.handler',
         'GET /storefront-cron': 'upload-api/functions/storefront-cron.handler',

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -142,6 +142,7 @@ export function UploadApiStack({ stack, app }) {
             REQUIRE_PAYMENT_PLAN: process.env.REQUIRE_PAYMENT_PLAN ?? '',
             UPLOAD_API_DID: process.env.UPLOAD_API_DID ?? '',
             UPLOAD_API_ALIAS: process.env.UPLOAD_API_ALIAS ?? '',
+            UPLOAD_API_DEPRECATED_DIDS: process.env.UPLOAD_API_DEPRECATED_DIDS ?? '',
             STRIPE_PRICING_TABLE_ID: process.env.STRIPE_PRICING_TABLE_ID ?? '',
             STRIPE_FREE_TRIAL_PRICING_TABLE_ID: process.env.STRIPE_FREE_TRIAL_PRICING_TABLE_ID ?? '',
             STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY ?? '',

--- a/upload-api/functions/get.js
+++ b/upload-api/functions/get.js
@@ -76,7 +76,7 @@ export async function didDocumentGet() {
   const signer = getServiceSigner({ did: UPLOAD_API_DID, privateKey: PRIVATE_KEY })
   const webKey = signer.did()
   const publicKeyMultibase = signer.toDIDKey().replace('did:key:', '')
-  const publicKeys = [
+  const verificationMethod = [
     {
       id: `${webKey}#owner`,
       type: 'Ed25519VerificationKey2020',
@@ -103,9 +103,9 @@ export async function didDocumentGet() {
     body: JSON.stringify({
       '@context': 'https://w3id.org/did/v1',
       id: webKey,
-      publicKey: publicKeys,
-      assertionMethod: publicKeys.map(k => k.id),
-      authentication: publicKeys.map(k => k.id)
+      verificationMethod,
+      assertionMethod: verificationMethod.map(k => k.id),
+      authentication: verificationMethod.map(k => k.id)
     }, null, 2),
   }
 }

--- a/upload-api/functions/get.js
+++ b/upload-api/functions/get.js
@@ -71,12 +71,12 @@ export const error = Sentry.AWSLambda.wrapHandler(errorGet)
  * AWS HTTP Gateway handler for GET /.well-known/did.json
  */
 export async function didDocumentGet() {
-  const { UPLOAD_API_DID, UPLOAD_API_ALIAS } = process.env
+  const { UPLOAD_API_DID, UPLOAD_API_ALIAS, UPLOAD_API_DEPRECATED_DIDS } = process.env
   const { PRIVATE_KEY } = Config
   const signer = getServiceSigner({ did: UPLOAD_API_DID, privateKey: PRIVATE_KEY })
   const webKey = signer.did()
   const publicKeyMultibase = signer.toDIDKey().replace('did:key:', '')
-  const verificationMethod = [
+  const verificationMethods = [
     {
       id: `${webKey}#owner`,
       type: 'Ed25519VerificationKey2020',
@@ -94,6 +94,16 @@ export async function didDocumentGet() {
         publicKeyMultibase
       }))
   ]
+  const deprecatedVerificationMethods =
+    (UPLOAD_API_DEPRECATED_DIDS ?? '')
+      .split(',')
+      .map(s => s.trim())
+      .map((deprecatedKey, i) => ({
+        id: `${webKey}#deprecated${i}`,
+        type: 'Ed25519VerificationKey2020',
+        controller: webKey,
+        publicKeyMultibase: deprecatedKey.replace('did:key:', '')
+      }))
 
   return {
     statusCode: 200,
@@ -103,9 +113,9 @@ export async function didDocumentGet() {
     body: JSON.stringify({
       '@context': 'https://w3id.org/did/v1',
       id: webKey,
-      verificationMethod,
-      assertionMethod: verificationMethod.map(k => k.id),
-      authentication: verificationMethod.map(k => k.id)
+      verificationMethod: [...verificationMethods, ...deprecatedVerificationMethods],
+      assertionMethod: verificationMethods.map(k => k.id),
+      authentication: verificationMethods.map(k => k.id)
     }, null, 2),
   }
 }


### PR DESCRIPTION
Serve a DID document like the following at `/.well-known/did.json`. It allows external entities to resolve and verify our `did:web`:

```json
{
  "@context": "https://w3id.org/did/v1",
  "id": "did:web:up.storacha.network",
  "verificationMethod": [
    {
      "id": "did:web:up.storacha.network#owner",
      "type": "Ed25519VerificationKey2020",
      "controller": "did:web:up.storacha.network",
      "publicKeyMultibase": "z6MknTPdpBGfFysJWCJn7SbhrAA7Xmp6ZCnjH9dPxJy2T7sk"
    }
  ],
  "assertionMethod": [
    "did:web:up.storacha.network#owner"
  ],
  "authentication": [
    "did:web:up.storacha.network#owner"
  ]
}
```