### PR TITLE
feat: render bsky.storage pricing table

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -47,6 +47,7 @@ MAILSLURP_TIMEOUT = '120000'
 # these values are from the Stripe test environment
 STRIPE_PRICING_TABLE_ID = 'prctbl_1NzhdvF6A5ufQX5vKNZuRhie'
 STRIPE_FREE_TRIAL_PRICING_TABLE_ID = 'prctbl_1QHa8sF6A5ufQX5vJ8SUZUjq'
+STRIPE_BLUESKY_PRICING_TABLE_ID = 'prctbl_1RQY3FF6A5ufQX5v6w1JIYwd'
 STRIPE_PUBLISHABLE_KEY = 'pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC'
 # this is used in tests and should always be set to the test env secret key
 STRIPE_TEST_SECRET_KEY = ''

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -145,6 +145,7 @@ export function UploadApiStack({ stack, app }) {
             UPLOAD_API_DEPRECATED_DIDS: process.env.UPLOAD_API_DEPRECATED_DIDS ?? '',
             STRIPE_PRICING_TABLE_ID: process.env.STRIPE_PRICING_TABLE_ID ?? '',
             STRIPE_FREE_TRIAL_PRICING_TABLE_ID: process.env.STRIPE_FREE_TRIAL_PRICING_TABLE_ID ?? '',
+            STRIPE_BLUESKY_PRICING_TABLE_ID: process.env.STRIPE_BLUESKY_PRICING_TABLE_ID ?? '',
             STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY ?? '',
             DEAL_TRACKER_DID: process.env.DEAL_TRACKER_DID ?? '',
             DEAL_TRACKER_URL: process.env.DEAL_TRACKER_URL ?? '',


### PR DESCRIPTION
If the `access/authorize` capability is invoked with `nb.app` set to `bsky-backups`, render the same pricing table we render on bsky.storage, which redirects them to that app rather than console.storacha.network after auth.

See https://github.com/storacha/upload-service/pull/264 for the other half of this.