### PR TITLE
feat: port #466 to legacy prod hotfix

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -61,3 +61,5 @@ REFERRALS_ENDPOINT = 'https://staging.referrals.storacha.network'
 # GitHub OAuth (optional)
 GITHUB_CLIENT_ID = ''
 GITHUB_CLIENT_SECRET = ''
+HUMANODE_TOKEN_ENDPOINT='https://auth.demo-storacha-2025-03-31.oauth2.humanode.io/oauth2/token'
+HUMANODE_CLIENT_ID='e9756297-b2d1-4bbe-a139-a9ad1cdc43ee'

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@web-std/stream": "^1.0.3",
         "@web3-storage/upload-api": "^19.1.0",
         "aws-cdk-lib": "2.171.1",
+        "jwt-decode": "^4.0.0",
         "sst": "^2.47.3"
       },
       "devDependencies": {
@@ -63395,6 +63396,14 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "license": "MIT"
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@web-std/stream": "^1.0.3",
     "@web3-storage/upload-api": "^19.1.0",
     "aws-cdk-lib": "2.171.1",
+    "jwt-decode": "^4.0.0",
     "sst": "^2.47.3"
   },
   "simple-git-hooks": {

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -44,7 +44,7 @@ export function UploadApiStack({ stack, app }) {
 
   // Get references to constructs created in other stacks
   const { carparkBucket } = use(CarparkStack)
-  const { allocationTable, storeTable, uploadTable, delegationBucket, delegationTable, revocationTable, adminMetricsTable, spaceMetricsTable, consumerTable, subscriptionTable, rateLimitTable, pieceTable, privateKey, contentClaimsPrivateKey, githubClientSecret } = use(UploadDbStack)
+  const { allocationTable, humanodeTable, storeTable, uploadTable, delegationBucket, delegationTable, revocationTable, adminMetricsTable, spaceMetricsTable, consumerTable, subscriptionTable, rateLimitTable, pieceTable, privateKey, contentClaimsPrivateKey, githubClientSecret, humanodeClientSecret } = use(UploadDbStack)
   const { invocationBucket, taskBucket, workflowBucket, ucanStream } = use(UcanInvocationStack)
   const { customerTable, spaceDiffTable, spaceSnapshotTable, egressTrafficTable, stripeSecretKey } = use(BillingDbStack)
   const { pieceOfferQueue, filecoinSubmitQueue } = use(FilecoinStack)
@@ -70,6 +70,7 @@ export function UploadApiStack({ stack, app }) {
           timeout: '60 seconds',
           permissions: [
             allocationTable,
+            humanodeTable,
             storeTable,
             uploadTable,
             customerTable,
@@ -105,6 +106,7 @@ export function UploadApiStack({ stack, app }) {
             UPLOAD_TABLE_NAME: uploadTable.tableName,
             CONSUMER_TABLE_NAME: consumerTable.tableName,
             CUSTOMER_TABLE_NAME: customerTable.tableName,
+            HUMANODE_TABLE_NAME: humanodeTable.tableName,
             SUBSCRIPTION_TABLE_NAME: subscriptionTable.tableName,
             SPACE_METRICS_TABLE_NAME: spaceMetricsTable.tableName,
             RATE_LIMIT_TABLE_NAME: rateLimitTable.tableName,
@@ -151,14 +153,17 @@ export function UploadApiStack({ stack, app }) {
             CONTENT_CLAIMS_URL,
             CONTENT_CLAIMS_PROOF,
             HOSTED_ZONE: hostedZone ?? '',
-            GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID ?? ''
+            GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID ?? '',
+            HUMANODE_TOKEN_ENDPOINT: process.env.HUMANODE_TOKEN_ENDPOINT ?? '',
+            HUMANODE_CLIENT_ID: process.env.HUMANODE_CLIENT_ID ?? ''
           },
           bind: [
             privateKey,
             ucanInvocationPostbasicAuth,
             stripeSecretKey,
             contentClaimsPrivateKey,
-            githubClientSecret
+            githubClientSecret,
+            humanodeClientSecret
           ]
         }
       },
@@ -178,6 +183,7 @@ export function UploadApiStack({ stack, app }) {
         'GET /metrics/{proxy+}': 'upload-api/functions/metrics.handler',
         'GET /sample': 'upload-api/functions/sample.handler',
         'GET /oauth/callback': 'upload-api/functions/oauth-callback.handler',
+        'GET /oauth/humanode/callback': 'upload-api/functions/oauth-humanode-callback.handler',
       },
       accessLog: {
         format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'

--- a/stacks/upload-db-stack.js
+++ b/stacks/upload-db-stack.js
@@ -10,7 +10,8 @@ import {
   revocationTableProps,
   rateLimitTableProps,
   adminMetricsTableProps,
-  spaceMetricsTableProps
+  spaceMetricsTableProps,
+  humanodeTableProps
 } from '../upload-api/tables/index.js'
 import {
   pieceTableProps
@@ -33,6 +34,9 @@ export function UploadDbStack({ stack, app }) {
   const contentClaimsPrivateKey = new Config.Secret(stack, 'CONTENT_CLAIMS_PRIVATE_KEY')
 
   const githubClientSecret = new Config.Secret(stack, 'GITHUB_CLIENT_SECRET')
+  const humanodeClientSecret = new Config.Secret(stack, 'HUMANODE_CLIENT_SECRET')
+
+  const humanodeTable = new Table(stack, 'humanode', humanodeTableProps)
 
   /**
    * The allocation table tracks allocated multihashes per space.
@@ -109,6 +113,7 @@ export function UploadDbStack({ stack, app }) {
 
   return {
     allocationTable,
+    humanodeTable,
     storeTable,
     uploadTable,
     pieceTable,
@@ -122,6 +127,7 @@ export function UploadDbStack({ stack, app }) {
     spaceMetricsTable,
     privateKey,
     contentClaimsPrivateKey,
-    githubClientSecret
+    githubClientSecret,
+    humanodeClientSecret
   }
 }

--- a/upload-api/functions/oauth-humanode-callback.js
+++ b/upload-api/functions/oauth-humanode-callback.js
@@ -1,0 +1,238 @@
+import { Config } from 'sst/node/config'
+import * as Sentry from '@sentry/serverless'
+import { base64url } from 'multiformats/bases/base64'
+import { Delegation, ok } from '@ucanto/core'
+import * as Validator from '@ucanto/validator'
+import { Verifier } from '@ucanto/principal'
+import * as Access from '@web3-storage/capabilities/access'
+import * as DidMailto from '@web3-storage/did-mailto'
+import { mustGetEnv } from '../../lib/env.js'
+import { createCustomerStore } from '../../billing/tables/customer.js'
+import { getServiceSigner } from '../config.js'
+import { jwtDecode } from "jwt-decode"
+import { createHumanodesTable } from '../stores/humanodes.js'
+
+
+/**
+ * @import { Endpoints } from '@octokit/types'
+ * @import { Signer, Result } from '@ucanto/interface'
+ * @typedef {{
+ *   getOAuthAccessToken: (params: { code: string }) => Promise<Result<{ access_token: string }>>
+ *   getUser: (params: { accessToken: string }) => Promise<Result<Endpoints['GET /user']['response']['data']>>
+ *   getUserEmails: (params: { accessToken: string }) => Promise<Result<Endpoints['GET /user/emails']['response']['data']>>
+ * }} GitHub
+ * @typedef {{
+ *   serviceSigner: Signer
+ *   customerStore: import('../../billing/lib/api.js').CustomerStore
+ *   humanodeStore: import('../types.js').HumanodeStore
+ * }} Context
+ */
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 0,
+})
+
+const HUMANODE_TOKEN_ENDPOINT = mustGetEnv('HUMANODE_TOKEN_ENDPOINT')
+const HUMANODE_CLIENT_ID = mustGetEnv('HUMANODE_CLIENT_ID')
+const HUMANODE_CLIENT_SECRET = Config.HUMANODE_CLIENT_SECRET
+
+/**
+ * AWS HTTP Gateway handler for GET /oauth/humanode/callback.
+ *
+ * @param {import('aws-lambda').APIGatewayProxyEventV2} request
+ * @param {import('aws-lambda').Context} [context]
+ */
+export const oauthCallbackGet = async (request, context) => {
+  const {
+    serviceSigner,
+    customerStore,
+    humanodeStore
+  } = getContext(context?.clientContext?.Custom)
+
+  const code = request.queryStringParameters?.code
+  if (!code) {
+    console.error('missing code in query params')
+    return htmlResponse(400, getUnexpectedErrorResponseHTML('Query params are missing code'))
+  }
+
+  // fetch the auth token from Humanode
+  const tokenResponse = await fetch(HUMANODE_TOKEN_ENDPOINT, {
+    method: 'POST', body: new URLSearchParams(
+      {
+        client_id: HUMANODE_CLIENT_ID,
+        client_secret: HUMANODE_CLIENT_SECRET,
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: `https://${request.headers.host}${request.rawPath}`
+      }
+    )
+  })
+  const tokenResult = await tokenResponse.json()
+  const humanodeIdToken = jwtDecode(tokenResult.id_token)
+  const humanodeId = humanodeIdToken.sub
+  if (!humanodeId) {
+    console.error("humanodeId is not undefined, this is very strange")
+    return htmlResponse(500, getUnexpectedErrorResponseHTML('Failed to get Humanode ID'))
+  }
+
+  const existsResponse = await humanodeStore.exists(humanodeId)
+  if (existsResponse.error){
+    return htmlResponse(500, getUnexpectedErrorResponseHTML(existsResponse.error.message))
+  }
+  if (existsResponse.ok){
+    return htmlResponse(400, getDuplicateHumanodeResponseHTML())
+  }
+
+  // validate the access/authorize delegation and pull the customer email out of it
+  const extractRes = await Delegation.extract(base64url.decode(request.queryStringParameters?.state ?? ''))
+  if (extractRes.error) {
+    console.error('decoding access/authorize delegation', extractRes.error)
+    return htmlResponse(400, getUnexpectedErrorResponseHTML('Failed to decode access/authorization delegation.'))
+  }
+  const authRequest =
+    /** @type {import('@ucanto/interface').Invocation<import('@storacha/upload-api').AccessAuthorize>} */
+    (extractRes.ok)
+  const accessRes = await Validator.access(authRequest, {
+    capability: Access.authorize,
+    authority: serviceSigner,
+    principal: Verifier,
+    validateAuthorization: () => ok({})
+  })
+  if (accessRes.error) {
+    console.error('validating access/authorize delegation', accessRes.error)
+
+    return htmlResponse(400, getUnexpectedErrorResponseHTML('Failed to validate access/authorization delegation.'))
+  }
+
+  if (!accessRes.ok.capability.nb.iss) {
+    return htmlResponse(400, getUnexpectedErrorResponseHTML('Account DID not included in authorize request.'))
+  }
+
+  let customer
+  try {
+    customer = DidMailto.fromString(accessRes.ok.capability.nb.iss)
+  } catch (e) {
+    console.error("error parsing did:mailto:", e)
+    return htmlResponse(400, getUnexpectedErrorResponseHTML('Invalid Account DID received.'))
+  }
+
+  // add a customer with a trial product
+  const customerPutRes = await customerStore.put({
+    customer,
+    product: 'did:web:trial.storacha.network',
+    details: JSON.stringify({ humanode: { id: humanodeId } }),
+    insertedAt: new Date()
+  })
+  if (!customerPutRes.ok) {
+    console.error(`putting customer: ${customer}`, customerPutRes.error)
+    return htmlResponse(500, getUnexpectedErrorResponseHTML('Failed to update customer store.'))
+  }
+
+  await humanodeStore.add(humanodeId)
+
+  return htmlResponse(200, getResponseHTML())
+}
+
+export const handler = Sentry.AWSLambda.wrapHandler((event) => oauthCallbackGet(event))
+
+/**
+ * @param {Context} [customContext]
+ * @returns {Context}
+ */
+const getContext = (customContext) => {
+  if (customContext) return customContext
+
+  const region = process.env.AWS_REGION || 'us-west-2'
+
+  const serviceSigner = getServiceSigner({
+    did: process.env.UPLOAD_API_DID,
+    privateKey: Config.PRIVATE_KEY
+  })
+
+  const customerStore = createCustomerStore({ region }, { tableName: mustGetEnv('CUSTOMER_TABLE_NAME') })
+  const humanodeStore = createHumanodesTable(region, mustGetEnv('HUMANODE_TABLE_NAME'))
+  
+  return {
+    serviceSigner,
+    customerStore,
+    humanodeStore
+  }
+}
+
+/**
+ * @param {number} statusCode
+ * @param {string} body 
+ * @returns 
+ */
+function htmlResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'text/html' },
+    body: Buffer.from(body).toString('base64'),
+    isBase64Encoded: true,
+  }
+}
+
+const getResponseHTML = () => `
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Authorized - Storacha Network</title>
+  </head>
+  <body style="font-family:sans-serif;color:#000">
+    <div style="height:100vh;display:flex;align-items:center;justify-content:center">
+      <div style="text-align:center">
+        <img src="https://w3s.link/ipfs/bafybeihinjwsn3kgjrlpdada4xingozsni3boywlscxspc5knatftauety/storacha-bug.svg" alt="Storacha - Decentralized Hot Storage Layer on Filecoin">
+        <h1 style="font-weight:normal">Authorization Successful</h1>
+        <p>You have been granted a free Storacha storage plan.</p>
+        <p>You may now close this window.</p>
+      </div>
+    </div>
+  </body>
+</html>
+`.trim()
+
+const getDuplicateHumanodeResponseHTML = () => `
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Authorized - Storacha Network</title>
+  </head>
+  <body style="font-family:sans-serif;color:#000">
+    <div style="height:100vh;display:flex;align-items:center;justify-content:center">
+      <div style="text-align:center">
+        <img src="https://w3s.link/ipfs/bafybeihinjwsn3kgjrlpdada4xingozsni3boywlscxspc5knatftauety/storacha-bug.svg" alt="Storacha - Decentralized Hot Storage Layer on Filecoin">
+        <h1 style="font-weight:normal">Plan Selection Unsuccessful</h1>
+        <p>The identified human has already claimed their free plan.</p>
+        <p>You may now close this window.</p>
+      </div>
+    </div>
+  </body>
+</html>
+`.trim()
+
+/**
+ * 
+ * @param {string} message 
+ * @returns 
+ */
+const getUnexpectedErrorResponseHTML = (message) => `
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Authorized - Storacha Network</title>
+  </head>
+  <body style="font-family:sans-serif;color:#000">
+    <div style="height:100vh;display:flex;align-items:center;justify-content:center">
+      <div style="text-align:center">
+        <img src="https://w3s.link/ipfs/bafybeihinjwsn3kgjrlpdada4xingozsni3boywlscxspc5knatftauety/storacha-bug.svg" alt="Storacha - Decentralized Hot Storage Layer on Filecoin">
+        <h1 style="font-weight:normal">Unexpected Error</h1>
+        <p>An unexpected error occured while trying to authenticate you: ${message} </p>
+        <p>Please close this window and try again.</p>
+      </div>
+    </div>
+  </body>
+</html>
+`.trim()

--- a/upload-api/stores/humanodes.js
+++ b/upload-api/stores/humanodes.js
@@ -1,0 +1,81 @@
+import {
+  GetItemCommand,
+  PutItemCommand,
+} from '@aws-sdk/client-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
+import { getDynamoClient } from '../../lib/aws/dynamo.js'
+
+/**
+ * Abstraction layer to handle operations on humanodes table.
+ *
+ * @param {string} region
+ * @param {string} tableName
+ * @param {object} [options]
+ * @param {string} [options.endpoint]
+ */
+export function createHumanodesTable(region, tableName, options = {}) {
+  const dynamoDb = getDynamoClient({
+    region,
+    endpoint: options.endpoint,
+  })
+
+  return useHumanodesTable(dynamoDb, tableName)
+}
+
+/**
+ * A table to track Humanode IDs.
+ * 
+ * Humanode has a facial hashing system that gives tells us whether we've
+ * seen a particular face before. This table tracks whether we've seen
+ * a specific face hash.
+ * 
+ * We use the name `sub` for the face hash because that is the name it
+ * is given in the JWT we receive it in - it's short for `subject`.
+ * 
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoDb
+ * @param {string} tableName
+ * @returns {import('../types.ts').HumanodeStore}
+ */
+export function useHumanodesTable(dynamoDb, tableName) {
+  return {
+    async add(sub) {
+      try {
+        await dynamoDb.send(new PutItemCommand({
+          TableName: tableName,
+          Item: marshall({
+            sub
+          }),
+        }))
+        return { ok: {} }
+      } catch (/** @type {any} */err) {
+        return {
+          error: {
+            name: 'UnexpectedError',
+            message: err.message,
+            cause: err
+          }
+        }
+      }
+    },
+
+    async exists(sub) {
+      try {
+        const result = await dynamoDb.send(new GetItemCommand({
+          TableName: tableName,
+          Key: marshall({
+            sub
+          })
+        }))
+        return { ok: Boolean(result.Item) }
+      } catch (/** @type {any} */err) {
+        return {
+          error: {
+            name: 'UnexpectedError',
+            message: err.message,
+            cause: err
+          }
+        }
+      }
+    }
+  }
+}

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -139,6 +139,18 @@ export const revocationTableProps = {
   primaryIndex: { partitionKey: 'revoke'}
 }
 
+/**
+ * 
+ * @type TableProps 
+ */
+export const humanodeTableProps = {
+  fields: {
+    // the humanode "subject" - `sub` matches the name it is given in the JWT we receive.
+    sub: 'string',
+  },
+  primaryIndex: { partitionKey: 'sub'}
+}
+
 /** @type TableProps */
 export const adminMetricsTableProps = {
   fields: {

--- a/upload-api/types.ts
+++ b/upload-api/types.ts
@@ -3,7 +3,7 @@ import { DID, Delegation, Block, UCANLink, ByteView, ReceiptModel, DIDKey, Resul
 import { UnknownLink } from 'multiformats'
 import { CID } from 'multiformats/cid'
 import { Kinesis } from '@aws-sdk/client-kinesis'
-import { AccountDID, ProviderDID, Service, SpaceDID, CarStoreBucket, AllocationsStorage, PlanCreateAdminSessionSuccess, PlanCreateAdminSessionFailure, AgentStore } from '@web3-storage/upload-api'
+import { AccountDID, ProviderDID, Service, SpaceDID, CarStoreBucket, AllocationsStorage, PlanCreateAdminSessionSuccess, PlanCreateAdminSessionFailure, AgentStore, UnexpectedError } from '@web3-storage/upload-api'
 
 export type {
   UnknownLink,
@@ -270,6 +270,9 @@ declare module 'sst/node/config' {
     },
     GITHUB_CLIENT_SECRET: {
       value: string
+    },
+    HUMANODE_CLIENT_SECRET: {
+      value: string
     }
   }
 }
@@ -298,4 +301,10 @@ export interface ReferralsStore {
   getReferredBy: (email: string) => Promise<Referral>
 }
 
+export interface HumanodeStore {
+  add: (sub: string) => Promise<Result<Unit, UnexpectedError>>
+  exists: (sub: string) => Promise<Result<boolean, UnexpectedError>>
+}
+
 export {}
+


### PR DESCRIPTION
feat: add Humanode verification callback (#466) :

Add a Humanode OAuth callback that will give a "free storage with no credit card" plan to a user who uses Humanode to prove they are a unique person.

<img width="1220" alt="Screenshot 2025-04-10 at 3 42 22 PM" src="https://github.com/user-attachments/assets/3ae37e80-dd0c-4348-8ad2-1761ce4213cb" />
<img width="1220" alt="Screenshot 2025-04-10 at 3 43 09 PM" src="https://github.com/user-attachments/assets/dddcc6da-2863-465f-9c1c-808f40a172e1" />
<img width="1225" alt="Screenshot 2025-04-10 at 3 44 11 PM" src="https://github.com/user-attachments/assets/30f13cd5-4c52-4858-84ad-738d9b658c6d" />
<img width="1220" alt="Screenshot 2025-04-10 at 3 43 19 PM" src="https://github.com/user-attachments/assets/b56609c3-ea21-4e15-a09a-12c3f9c71a95" />

The one remaining concern I have with this code is the duplication in the templates - we now have 4 blobs of HTML like this across the two OAuth handlers and I'm not sure the best way to consolidate - any thoughts @alanshaw ?