### PR TITLE
fix: allow roundabout redirect to storage node

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: ^1.0.5
       version: 1.0.5
     '@storacha/capabilities':
-      specifier: ^1.5.0
-      version: 1.5.0
+      specifier: ^1.7.0
+      version: 1.7.0
     '@storacha/client':
       specifier: ^1.2.6
       version: 1.2.6
@@ -371,7 +371,7 @@ importers:
         version: 1.0.5
       '@storacha/capabilities':
         specifier: 'catalog:'
-        version: 1.5.0
+        version: 1.7.0
       '@storacha/client':
         specifier: 'catalog:'
         version: 1.2.6(encoding@0.1.13)
@@ -488,7 +488,7 @@ importers:
         version: 7.120.3
       '@storacha/capabilities':
         specifier: 'catalog:'
-        version: 1.5.0
+        version: 1.7.0
       '@ucanto/interface':
         specifier: 'catalog:'
         version: 10.3.0
@@ -826,9 +826,15 @@ importers:
       '@ipld/dag-pb':
         specifier: 'catalog:'
         version: 4.1.3
+      '@storacha/capabilities':
+        specifier: 'catalog:'
+        version: 1.7.0
       '@ucanto/core':
         specifier: 'catalog:'
         version: 10.4.0
+      '@ucanto/principal':
+        specifier: 'catalog:'
+        version: 9.0.2
       '@web3-storage/data-segment':
         specifier: 'catalog:'
         version: 5.3.0
@@ -865,7 +871,7 @@ importers:
         version: 3.4.5
       '@storacha/capabilities':
         specifier: 'catalog:'
-        version: 1.5.0
+        version: 1.7.0
       '@storacha/did-mailto':
         specifier: 'catalog:'
         version: 1.0.2
@@ -922,7 +928,7 @@ importers:
         version: 1.1.1
       '@storacha/capabilities':
         specifier: 'catalog:'
-        version: 1.5.0
+        version: 1.7.0
       '@storacha/did-mailto':
         specifier: 'catalog:'
         version: 1.0.2
@@ -4170,9 +4176,6 @@ packages:
   '@storacha/blob-index@1.1.0-rc.0':
     resolution: {integrity: sha512-LTPfv0POAKbFJAem1Iz7utZzlh2auIhUZ7TQYz9YM9tZOWXwWz4oKXv6v0sXsqK5NGZsnolT5iQbNJ2f8GXZBg==}
     engines: {node: '>=16.15'}
-
-  '@storacha/capabilities@1.5.0':
-    resolution: {integrity: sha512-URShZ1RkEHsQa/uuEtLcuQGTZ5gzClfJ4UVm0KRivGnP+p8GvFnXnzmPRvaaYOkw/PhChe3e5oeVzvVNSOSsiA==}
 
   '@storacha/capabilities@1.7.0':
     resolution: {integrity: sha512-YMIuocTgaVpqlgyds5NG+eJqfr+dfFkxdk33lJcFIRD30SZaGiA8vQ0ZPUHqcC9Azj0XZCRexz6nHXqEsn1aag==}
@@ -16891,7 +16894,7 @@ snapshots:
       '@ipld/car': 5.4.0
       '@ipld/dag-ucan': 3.4.5
       '@scure/bip39': 1.5.4
-      '@storacha/capabilities': 1.5.0
+      '@storacha/capabilities': 1.7.0
       '@storacha/did-mailto': 1.0.2
       '@storacha/one-webcrypto': 1.0.1
       '@ucanto/client': 9.0.1
@@ -16931,7 +16934,7 @@ snapshots:
   '@storacha/blob-index@1.0.5':
     dependencies:
       '@ipld/dag-cbor': 9.2.2
-      '@storacha/capabilities': 1.5.0
+      '@storacha/capabilities': 1.7.0
       '@storacha/one-webcrypto': 1.0.1
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0
@@ -16961,16 +16964,6 @@ snapshots:
       multiformats: 13.3.6
       uint8arrays: 5.1.0
 
-  '@storacha/capabilities@1.5.0':
-    dependencies:
-      '@ucanto/core': 10.4.0
-      '@ucanto/interface': 10.3.0
-      '@ucanto/principal': 9.0.2
-      '@ucanto/transport': 9.2.0
-      '@ucanto/validator': 9.1.0
-      '@web3-storage/data-segment': 5.3.0
-      uint8arrays: 5.1.0
-
   '@storacha/capabilities@1.7.0':
     dependencies:
       '@ucanto/core': 10.4.0
@@ -16996,7 +16989,7 @@ snapshots:
       '@ipld/dag-ucan': 3.4.5
       '@storacha/access': 1.1.1
       '@storacha/blob-index': 1.0.5
-      '@storacha/capabilities': 1.5.0
+      '@storacha/capabilities': 1.7.0
       '@storacha/did-mailto': 1.0.2
       '@storacha/filecoin-client': 1.0.6
       '@storacha/upload-client': 1.0.9(encoding@0.1.13)
@@ -17028,7 +17021,7 @@ snapshots:
   '@storacha/filecoin-api@1.1.7':
     dependencies:
       '@ipld/dag-ucan': 3.4.5
-      '@storacha/capabilities': 1.5.0
+      '@storacha/capabilities': 1.7.0
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0
@@ -17042,7 +17035,7 @@ snapshots:
   '@storacha/filecoin-client@1.0.6':
     dependencies:
       '@ipld/dag-ucan': 3.4.5
-      '@storacha/capabilities': 1.5.0
+      '@storacha/capabilities': 1.7.0
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0
@@ -17094,7 +17087,7 @@ snapshots:
       '@ipld/dag-ucan': 3.4.5
       '@ipld/unixfs': 3.0.0
       '@storacha/blob-index': 1.0.5
-      '@storacha/capabilities': 1.5.0
+      '@storacha/capabilities': 1.7.0
       '@storacha/filecoin-client': 1.0.6
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.4.0
@@ -17502,7 +17495,7 @@ snapshots:
       '@noble/ed25519': 1.7.3
       '@noble/hashes': 1.7.1
       '@ucanto/interface': 10.3.0
-      multiformats: 13.3.2
+      multiformats: 13.3.6
       one-webcrypto: 1.0.3
 
   '@ucanto/server@10.2.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   "@sentry/serverless": ^7.74.1
   "@storacha/access": ^1.1.1
   "@storacha/blob-index": ^1.0.5
-  "@storacha/capabilities": ^1.5.0
+  "@storacha/capabilities": ^1.7.0
   "@storacha/client": ^1.2.6
   "@storacha/did-mailto": ^1.0.1
   "@storacha/filecoin-api": ^1.1.6

--- a/roundabout/constants.js
+++ b/roundabout/constants.js
@@ -13,3 +13,6 @@ export const PIECE_V1_MULTIHASH = 0x10_12
 
 /** https://github.com/multiformats/multicodec/pull/331/files */
 export const PIECE_V2_MULTIHASH = 0x10_11
+
+export const CARPARK_DOMAIN =
+  `carpark-${process.env.SST_STAGE ?? 'dev'}-0.r2.w3s.link`

--- a/roundabout/index.js
+++ b/roundabout/index.js
@@ -1,8 +1,6 @@
 import { getSignedUrl as getR2SignedUrl } from '@aws-sdk/s3-request-presigner'
 import { GetObjectCommand } from '@aws-sdk/client-s3'
-import { base58btc } from 'multiformats/bases/base58'
-
-import { RAW_CODE } from './constants.js'
+import { RAW_CODE, CARPARK_DOMAIN } from './constants.js'
 
 /**
  * @typedef {import('multiformats').CID} CID
@@ -48,20 +46,39 @@ export function getSigner (s3Client, bucketName) {
  * @param {S3Client} config.s3Client
  * @param {string} config.bucket
  * @param {number} config.expiresIn
+ * @param {import('@storacha/indexing-service-client/api').IndexingServiceClient} config.indexingService
  */
-export function contentLocationResolver ({ s3Client, bucket, expiresIn }) {
+export function contentLocationResolver ({ s3Client, bucket, expiresIn, indexingService }) {
   const signer = getSigner(s3Client, bucket)
   /**
    * @param {CID} cid
    */
   return async function locateContent (cid) {
-    const carKey = `${cid}/${cid}.car`
-
-    if (cid.code === RAW_CODE) {
-      const encodedMultihash = base58btc.encode(cid.multihash.bytes)
-      const blobKey = `${encodedMultihash}/${encodedMultihash}.blob`
-      return signer.getUrl(blobKey, { expiresIn })
+    if (cid.code !== RAW_CODE) {
+      const carKey = `${cid}/${cid}.car`
+      return signer.getUrl(carKey, { expiresIn })
     }
-    return signer.getUrl(carKey, { expiresIn })
+
+    const res = await indexingService.queryClaims({ hashes: [cid.multihash] })
+    if (res.error) {
+      console.error(res.error)
+      throw new Error('indexing service query failed', { cause: res.error })
+    }
+
+    const locations = []
+    for (const [, c] of res.ok.claims) {
+      if (c.type === 'assert/location') {
+        locations.push(...c.location)
+        for (const url of c.location) {
+          // if location is a known carpark URI then return a signed URL
+          if (url.includes(CARPARK_DOMAIN)) {
+            const blobKey = new URL(url).pathname.slice(1)
+            return signer.getUrl(blobKey, { expiresIn })
+          }
+        }
+      }
+    }
+    // just return a random one
+    return locations[Math.floor(Math.random() * locations.length)]
   }
 }

--- a/roundabout/package.json
+++ b/roundabout/package.json
@@ -14,7 +14,9 @@
   "devDependencies": {
     "@ipld/car": "catalog:",
     "@ipld/dag-pb": "catalog:",
+    "@storacha/capabilities": "catalog:",
     "@ucanto/core": "catalog:",
+    "@ucanto/principal": "catalog:",
     "@web3-storage/data-segment": "catalog:",
     "ava": "catalog:",
     "multiformats": "catalog:",

--- a/roundabout/piece.js
+++ b/roundabout/piece.js
@@ -5,12 +5,8 @@ import { equals } from 'multiformats/bytes'
 import { PIECE_V1_CODE, PIECE_V1_MULTIHASH, PIECE_V2_MULTIHASH, RAW_CODE } from './constants.js'
 
 /**
- * @import { Delegation, Capability, Resource, UnknownLink } from '@ucanto/interface'
+ * @import { IndexingServiceClient } from '@storacha/indexing-service-client/api'
  */
-
-/** 
- * @typedef {import('@web3-storage/content-claims/client/api').Claim} Claim
- **/
 
 /**
  * Return the cid if it is a Piece CID or undefined if not
@@ -38,7 +34,7 @@ export function asPieceCidV1 (cid) {
  * Find the set of CIDs that are claimed to be equivalent to the Piece CID.
  * 
  * @param {CID} piece
- * @param {Client} [indexingService] - returns content claims for a cid
+ * @param {IndexingServiceClient} [indexingService] - returns content claims for a cid
  */
 export async function findEquivalentCids (piece, indexingService = createIndexingServiceClient()) {
   /** @type {Map<string, import('multiformats').UnknownLink>} */


### PR DESCRIPTION
This PR allows roundabout to redirect to storage nodes.

If the blob location is found in carpark bucket then create a signed URL as usual, otherwise redirect to URL in location claim.

Note: in order to redirect to nodes in other networks we this to land: https://github.com/storacha/js-indexing-service-client/pull/19