### PR TITLE
fix: blob deregister diff

### DIFF
--- a/upload-api/stores/blob-registry.js
+++ b/upload-api/stores/blob-registry.js
@@ -245,7 +245,7 @@ export const useBlobRegistry = (
         const spaceDiffResults = await buildSpaceDiffs({
           space,
           cause: cause.toString(),
-          delta: blobSize,
+          delta: -blobSize,
           receiptAt: dateNow,
           insertedAt: dateNow
         })


### PR DESCRIPTION
When de-registering a blob the diff size should be a negative number.