### PR TITLE
fix: re-add tables from new deploy

### DIFF
--- a/stacks/upload-db-stack.js
+++ b/stacks/upload-db-stack.js
@@ -2,6 +2,7 @@ import { Table, Bucket, Config } from 'sst/constructs'
 
 import {
   allocationTableProps,
+  blobRegistryTableProps,
   storeTableProps,
   uploadTableProps,
   consumerTableProps,
@@ -11,7 +12,9 @@ import {
   rateLimitTableProps,
   adminMetricsTableProps,
   spaceMetricsTableProps,
-  humanodeTableProps
+  storageProviderTableProps,
+  humanodeTableProps,
+  replicaTableProps
 } from '../upload-api/tables/index.js'
 import {
   pieceTableProps
@@ -43,6 +46,12 @@ export function UploadDbStack({ stack, app }) {
    * Used by the blob/* service capabilities.
    */
   const allocationTable = new Table(stack, 'allocation', allocationTableProps)
+
+  /**
+   * The blob registry table contains information about blob registrations
+   * per space.
+   */
+  const blobRegistryTable = new Table(stack, 'blob-registry', blobRegistryTableProps)
 
   /**
    * This table takes a stored CAR and makes an entry in the store table
@@ -111,8 +120,19 @@ export function UploadDbStack({ stack, app }) {
    */
   const spaceMetricsTable = new Table(stack, 'space-metrics', spaceMetricsTableProps)
 
+    /**
+   * This table tracks storage providers in the system.
+   */
+  const storageProviderTable = new Table(stack, 'storage-provider', storageProviderTableProps)
+
+  /**
+   * This table tracks replicas in the system.
+   */
+  const replicaTable = new Table(stack, 'replica', replicaTableProps)
+
   return {
     allocationTable,
+    blobRegistryTable,
     humanodeTable,
     storeTable,
     uploadTable,
@@ -125,9 +145,11 @@ export function UploadDbStack({ stack, app }) {
     revocationTable,
     adminMetricsTable,
     spaceMetricsTable,
+    storageProviderTable,
+    replicaTable,
     privateKey,
-    contentClaimsPrivateKey,
     githubClientSecret,
-    humanodeClientSecret
+    contentClaimsPrivateKey,
+    humanodeClientSecret,
   }
 }

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -19,6 +19,22 @@ export const storeTableProps = {
 }
 
 /** @type TableProps */
+export const blobRegistryTableProps = {
+  fields: {
+    space: 'string',      // `did:key:space`
+    digest: 'string',     // `zQm...`
+    size: 'number',       // `101`
+    cause: 'string',      // `baf...ucan` (CID of invocation UCAN)
+    insertedAt: 'string', // `2022-12-24T...`
+  },
+  // space + digest must be unique to satisfy index constraint
+  primaryIndex: { partitionKey: 'space', sortKey: 'digest' },
+  globalIndexes: {
+    digest: { partitionKey: 'digest', sortKey: 'space' }
+  }
+}
+
+/** @type TableProps */
 export const uploadTableProps = {
   fields: {
     space: 'string',        // `did:key:space`
@@ -181,4 +197,46 @@ export const blocksCarsPositionTableProps = {
     length: 'number',
   },
   primaryIndex: { partitionKey: 'blockmultihash', sortKey: 'carpath' }
+}
+
+/** @type TableProps */
+export const storageProviderTableProps = {
+  fields: {
+    // DID of the stroage provider.
+    provider: 'string',
+    // Public URL that accepts UCAN invocations.
+    endpoint: 'string',
+    // Proof the upload service can invoke blob/allocate and blob/accept.
+    proof: 'string',
+    // Weight determines chance of selection relative to other providers.
+    weight: 'number',
+    // Date and time the record was created (ISO 8601)
+    insertedAt: 'string',
+    // Date and time the record was last updated (ISO 8601)
+    updatedAt: 'string',
+  },
+  primaryIndex: { partitionKey: 'provider' }
+}
+
+/** @type {TableProps} */
+export const replicaTableProps = {
+  fields: {
+    /** Composite key with format: "space#digest" */
+    pk: 'string',
+    /** DID of Space the blob is registered in. */
+    space: 'string',
+    /** Base58btc encoded multihash of the blob. */
+    digest: 'string',
+    /** DID of the replica node. */
+    provider: 'string',
+    /** Status of the replication (allocated/transferred/failed). */
+    status: 'string',
+    /** CID of `blob/replica/allocate` UCAN that allocated the replica space. */
+    cause: 'string',
+    /** Date and time the record was created (ISO 8601) */
+    insertedAt: 'string',
+    /** Date and time the record was last updated (ISO 8601) */
+    updatedAt: 'string',
+  },
+  primaryIndex: { partitionKey: 'pk', sortKey: 'provider' }
 }


### PR DESCRIPTION
This PR adds the new tables present in the new deploy to the legacy deploy. They are unused here but should hopefully allow deploy without conflict.