### PR TITLE
fix: don't show pricing table after email confirmation to TG mini app or console users

### DIFF
--- a/upload-api/functions/validate-email.jsx
+++ b/upload-api/functions/validate-email.jsx
@@ -237,8 +237,8 @@ export async function validateEmailPost(request) {
     // TODO: use AppName.BskyBackups from @storacha/client/types once we upgrade that dependency
     // I'd have done it now but upgrading causes linting issues and I want to save 
     // that rabbithole for later
-    if (appName === 'bsky-backups') {
-      // don't show a pricing table to bsky.storage users
+    if ((appName === 'bsky-backups') || (appName === 'tg-miniapp') || (appName === 'console')) {
+      // don't show a pricing table to bsky.storage or tg miniapp users
       stripePricingTableId = null
     } else if (isReferred) {
       stripePricingTableId = context.stripeFreeTrialPricingTableId 

--- a/upload-api/functions/validate-email.jsx
+++ b/upload-api/functions/validate-email.jsx
@@ -237,7 +237,7 @@ export async function validateEmailPost(request) {
     // TODO: use AppName.BskyBackups from @storacha/client/types once we upgrade that dependency
     // I'd have done it now but upgrading causes linting issues and I want to save 
     // that rabbithole for later
-    if ((appName === 'bsky-backups') || (appName === 'tg-miniapp') || (appName === 'console')) {
+    if ((appName === 'bsky-backups') || (appName === 'tg-miniapp')) {
       // don't show a pricing table to bsky.storage or tg miniapp users
       stripePricingTableId = null
     } else if (isReferred) {

--- a/upload-api/functions/validate-email.jsx
+++ b/upload-api/functions/validate-email.jsx
@@ -234,11 +234,11 @@ export async function validateEmailPost(request) {
   const appName = facts.find(fact => fact.appName)?.appName
   if (!planCheckResult.ok?.product) {
     stripePublishableKey = context.stripePublishableKey
-    // TODO: use AppName.BskyBackups from @storacha/client/types once we upgrade that dependency
+    // TODO: use AppName.{BskyBackups,TGMiniapp,Console} from @storacha/client/types once we upgrade that dependency
     // I'd have done it now but upgrading causes linting issues and I want to save 
     // that rabbithole for later
-    if ((appName === 'bsky-backups') || (appName === 'tg-miniapp')) {
-      // don't show a pricing table to bsky.storage or tg miniapp users
+    if ((appName === 'bsky-backups') || (appName === 'tg-miniapp') || (appName === 'console')) {
+      // don't show a pricing table to bsky.storage, tg miniapp or console users
       stripePricingTableId = null
     } else if (isReferred) {
       stripePricingTableId = context.stripeFreeTrialPricingTableId 


### PR DESCRIPTION
the post-email plan picker is really an affordance for the CLI, but we can't update old versions of the CLI to pass along an `appName` fact so we have to go the other way - if `appName` is set to `tg-miniapp` or `console`, don't show the plan picker - users will see this UI when they go back to the app.