### PR TITLE
refactor(billing): update dry run script to accept parameters

### DIFF
--- a/billing/scripts/dry-run/README.md
+++ b/billing/scripts/dry-run/README.md
@@ -8,11 +8,17 @@ Create your own `.env.local` file and fill in the relevant details:
 cp billing/scripts/dry-run/.env.template billing/scripts/dry-run/.env.local
 ```
 
-Run the billing pipeline:
+You can run the billing pipeline using the following optional arguments:
+
+- `from=yyyy-mm-dd`: Start date. Defaults to the first day of the current month if not provided.
+- `to=yyyy-mm-dd`: End date. Defaults to the first day of the next month if not provided.
+- `customer=did:mailto:agent`: DID of the user account. Defaults to get all customers.
+
+**Example Command:**
 
 ```sh
 cd billing/scripts/dry-run
-node dry-run.js
+node dry-run.js from=2025-06-01 to=2025-07-01 customer=did:mailto:storacha.network:admin
 ```
 
 This will output a CSV file (`summary-[from]-[to].csv`) with ordered per customer information about what they will be charged.

--- a/billing/scripts/utils.js
+++ b/billing/scripts/utils.js
@@ -1,0 +1,57 @@
+import { startOfMonth } from '../lib/util.js'
+import { Schema } from '../data/lib.js'
+
+/**
+ * @typedef {import('../lib/api.js').CustomerDID} CustomerDID
+ */
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function validateDateArg(value) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value)
+}
+
+/**
+ * @param {string[]} args - Array of arguments in the format 'from=yyyy-mm-dd' or 'to=yyyy-mm-dd'.
+ * @returns {{ from?: Date, to: Date, customer?: CustomerDID }} - Object with parsed 'from' and 'to' dates.
+ * @throws {Error} If the arguments are invalid or improperly formatted.
+ */
+export function parseArgs(args) {
+  const fromArg = args.find((e) => e.includes('from='))?.split('from=')[1]
+  const toArg = args.find((e) => e.includes('to='))?.split('to=')[1]
+  const customer = /** @type CustomerDID */ (
+    args.find((e) => e.includes('customer='))?.split('customer=')[1]
+  )
+
+  if (
+    (fromArg && !validateDateArg(fromArg)) ||
+    (toArg && !validateDateArg(toArg))
+  ) {
+    throw new Error('Expected argument in the format yyyy-mm-dd')
+  }
+
+  if (customer && Schema.did({ method: 'mailto' }).read(customer).error) {
+    throw new Error(`Invalid customer format: expected 'did:mailto:agent'.`)
+  }
+
+  const from = fromArg ? new Date(fromArg) : undefined
+  const to = toArg
+    ? new Date(toArg)
+    : (() => {
+        const now = new Date()
+        now.setUTCMonth(now.getUTCMonth() + 1)
+        return startOfMonth(now) // until first day of next month
+      })()
+
+  if (from && from > to) {
+    throw new Error("'from' date must be earlier than 'to' date")
+  }
+
+  return {
+    from,
+    to,
+    customer,
+  }
+}


### PR DESCRIPTION
Adds three optional parameters to the dry run script: `from`, `to`, and `customer`.
These options are going to help @heyjay44 run the script for different time periods and specific customers as needed.