### PR TITLE
fix sso auth flow

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -73,6 +73,11 @@ export function UploadApiStack({ stack, app }) {
   const git = getGitInfo()
   const ucanInvocationPostbasicAuth = new Config.Secret(stack, 'UCAN_INVOCATION_POST_BASIC_AUTH')
 
+  // Dmail API Integration
+  const dmailApiKey = new Config.Secret(stack, 'DMAIL_API_KEY')
+  const dmailApiSecret = new Config.Secret(stack, 'DMAIL_API_SECRET')
+  const dmailJwtSecret = new Config.Secret(stack, 'DMAIL_JWT_SECRET')
+
   const apis = (customDomains ?? [undefined]).map((customDomain, idx) => {
     const hostedZone = customDomain?.hostedZone
     // the first customDomain will be web3.storage, and we don't want the apiId for that domain to have a second part, see PR of this change for context
@@ -143,6 +148,8 @@ export function UploadApiStack({ stack, app }) {
               DELEGATION_TABLE_NAME: delegationTable.tableName,
               DID: process.env.UPLOAD_API_DID ?? '',
               DISABLE_IPNI_PUBLISHING,
+              DMAIL_API_URL: process.env.DMAIL_API_URL ?? 'https://api.dmail.ai/open/api/storacha/getUserStatus',
+              ENABLE_CUSTOMER_TRIAL_PLAN: process.env.ENABLE_CUSTOMER_TRIAL_PLAN ?? 'false',
               EGRESS_TRAFFIC_QUEUE_URL: egressTrafficQueue.queueUrl,
               FILECOIN_SUBMIT_QUEUE_URL: filecoinSubmitQueue.queueUrl,
               INDEXING_SERVICE_DID,
@@ -181,6 +188,9 @@ export function UploadApiStack({ stack, app }) {
               indexingServiceProof,
               privateKey,
               stripeSecretKey,
+              dmailApiKey,
+              dmailApiSecret,
+              dmailJwtSecret,
             ]
           }
         },

--- a/upload-api/external-services/sso-providers/dmail-service.js
+++ b/upload-api/external-services/sso-providers/dmail-service.js
@@ -69,8 +69,6 @@ export class DmailSSOService {
    */
   async validate(ssoAuthParams) {
     const { authProvider, email, externalUserId, externalSessionToken } = ssoAuthParams
-
-    // Verify this is a DMAIL request
     if (authProvider !== 'dmail') {
       return error(new Error('Invalid auth provider for DMAIL service'))
     }

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -50,6 +50,7 @@ import { createEgressTrafficQueue } from '../../billing/queues/egress-traffic.js
 import { create as createRoutingService } from '../external-services/router.js'
 import { create as createBlobRetriever } from '../external-services/blob-retriever.js'
 import { createSSOService, createDmailSSOService } from '../external-services/sso-providers/index.js'
+import { uploadServiceURL } from '@storacha/client/service'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -323,13 +324,19 @@ export async function ucanInvocationRouter(request) {
   const routingService = createRoutingService(storageProviderTable, serviceSigner)
 
   const dmailSSOService = createDmailSSOService({
-    DMAIL_API_KEY: mustGetEnv('DMAIL_API_KEY'),
-    DMAIL_API_SECRET: mustGetEnv('DMAIL_API_SECRET'),
-    DMAIL_JWT_SECRET: process.env.DMAIL_JWT_SECRET || 'unused', // if undefined, we set it to a dummy value to bypass JWT validation
-    DMAIL_API_URL: process.env.DMAIL_API_URL || 'https://api.dmail.ai/open/api/storacha/getUserStatus',
+    apiKey: Config.DMAIL_API_KEY,
+    apiSecret: Config.DMAIL_API_SECRET,
+    jwtSecret: Config.DMAIL_JWT_SECRET || 'unused', // if undefined, we set it to a dummy value to bypass JWT validation
+    apiUrl: process.env.DMAIL_API_URL || 'https://api.dmail.ai/open/api/storacha/getUserStatus',
   })
-  const ssoService = createSSOService(serviceSigner, agentStore, [dmailSSOService])
 
+  // Build service URL from request data since we're in the same ucan server
+  const requestHost = request.headers?.host || request.headers?.Host
+  const serviceUrl = requestHost ? new URL(`https://${requestHost}`) : uploadServiceURL
+  const ssoService = createSSOService(serviceSigner, serviceUrl, agentStore, customerStore, [dmailSSOService],
+    process.env.ENABLE_CUSTOMER_TRIAL_PLAN === 'true'
+  )
+  
   let audience // accept invocations addressed to any alias
   const proofs = [] // accept attestations issued by any alias
   if (UPLOAD_API_ALIAS) {
@@ -419,7 +426,7 @@ export async function ucanInvocationRouter(request) {
   })
 
   const payload = fromLambdaRequest(request)
-  const response = await UploadAPI.handle(server, payload)
+        const response = await UploadAPI.handle(server, payload)
 
   return toLambdaResponse(response)
 }
@@ -509,10 +516,10 @@ function getLambdaEnv() {
       ({ ...knownWebDIDs, ...JSON.parse(process.env.PRINCIPAL_MAPPING || '{}') }),
     // set for testing
     dbEndpoint: process.env.DYNAMO_DB_ENDPOINT,
-    // SSO provider configuration (optional)
-    dmailApiKey: process.env.DMAIL_API_KEY,
-    dmailApiSecret: process.env.DMAIL_API_SECRET,
-    dmailJwtSecret: process.env.DMAIL_JWT_SECRET,
+    // SSO provider configuration
+    dmailApiKey: Config.DMAIL_API_KEY,
+    dmailApiSecret: Config.DMAIL_API_SECRET,
+    dmailJwtSecret: Config.DMAIL_JWT_SECRET,
     dmailApiUrl: process.env.DMAIL_API_URL,
   }
 }

--- a/upload-api/types.ts
+++ b/upload-api/types.ts
@@ -262,7 +262,17 @@ declare module 'sst/node/config' {
     /** @deprecated */
     CONTENT_CLAIMS_PRIVATE_KEY: {
       value: string
-    }
+    },
+    // Dmail API Integration
+    DMAIL_API_KEY: {
+      value: string
+    },
+    DMAIL_API_SECRET: {
+      value: string
+    },
+    DMAIL_JWT_SECRET: {
+      value: string
+    },
   }
 }
 


### PR DESCRIPTION
- Fixed secret definition for DMAIL integration
- Fixed SSO service initialization to use the connection URL from the request to execute the access/confirm invocation
- Created a feature flag `ENABLE_CUSTOMER_TRIAL_PLAN`, if enabled, will automatically add users from SSO flow into a trial plan
