### PR TITLE
feat(upload-api): return actual limits in getConsumer

### DIFF
--- a/billing/lib/api.ts
+++ b/billing/lib/api.ts
@@ -101,6 +101,7 @@ export type CustomerStore =
   & StoreLister<{}, Customer>
   & {
     updateProduct: (customer: CustomerDID, product: string) => Promise<Result<Unit, Failure>>
+    planLimit: (customer: CustomerDID) => Promise<Result<number, Failure>>
   }
 
 /**

--- a/billing/lib/product-info.js
+++ b/billing/lib/product-info.js
@@ -1,0 +1,12 @@
+const MB = 1024 * 1024
+const GB = 1024 * MB
+const TB = 1024 * GB
+
+/** @type {Record<string, { cost: number, overage: number, included: number, allowOverages: boolean }>} */
+export const productInfo = {
+  'did:web:trial.storacha.network': { cost: 0, overage: 0 / GB, included: 100 * MB, allowOverages: true },
+  'did:web:starter.web3.storage': { cost: 0, overage: 0.15 / GB, included: 5 * GB, allowOverages: true },
+  'did:web:lite.web3.storage': { cost: 10, overage: 0.05 / GB, included: 100 * GB, allowOverages: true },
+  'did:web:business.web3.storage': { cost: 100, overage: 0.03 / GB, included: 2 * TB, allowOverages: true },
+  'did:web:free.web3.storage': { cost: 0, overage: 0 / GB, included: 0, allowOverages: true },
+}

--- a/billing/scripts/dry-run/README.md
+++ b/billing/scripts/dry-run/README.md
@@ -25,7 +25,7 @@ This will output a CSV file (`summary-[from]-[to].csv`) with ordered per custome
 
 Much more info is collected, and is output to a JSON file `usage-[from]-[to].json` if you want to do some more spelunking.
 
-Note: this is only as up to date as the `productInfo` found in `helpers.js` which is (at time of writing) set as:
+Note: this is only as up to date as the `productInfo` found in `billing/lib/product-info.js` which is (at time of writing) set as:
 
 - `did:web:trial.storacha.network` cost: 0, overage: 0 / GB, included: 100 \* MB
 - `did:web:starter.web3.storage` cost: $0, overage: 0.15 / GB, included: 5 \* GB

--- a/billing/scripts/dry-run/helpers.js
+++ b/billing/scripts/dry-run/helpers.js
@@ -1,6 +1,7 @@
 import Big from 'big.js'
 import { StoreOperationFailure } from '../../tables/lib.js'
 import { EndOfQueue } from '../../test/helpers/queue.js'
+import { productInfo } from '../../lib/product-info.js'
 
 /**
  * @template T
@@ -38,18 +39,7 @@ export const createMemoryStore = () => {
   }
 }
 
-const MB = 1024 * 1024
-const GB = 1024 * MB
-const TB = 1024 * GB
-
-/** @type {Record<string, { cost: number, overage: number, included: number }>} */
-const productInfo = {
-  'did:web:trial.storacha.network': { cost: 0, overage: 0 / GB, included: 100 * MB },
-  'did:web:starter.web3.storage': { cost: 0, overage: 0.15 / GB, included: 5 * GB },
-  'did:web:lite.web3.storage': { cost: 10, overage: 0.05 / GB, included: 100 * GB },
-  'did:web:business.web3.storage': { cost: 100, overage: 0.03 / GB, included: 2 * TB },
-  'did:web:free.web3.storage': { cost: 0, overage: 0 / GB, included: 0 },
-}
+const GB = 1024 * 1024 * 1024
 
 /**
  * @param {string} product

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -243,17 +243,17 @@ export async function ucanInvocationRouter(request) {
   const stripe = new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' })
   const plansStorage = usePlansStore(customerStore, createStripeBillingProvider(stripe, customerStore))
   const rateLimitsStorage = createRateLimitTable(AWS_REGION, rateLimitTableName)
-  const spaceMetricsTable = createSpaceMetricsTable(AWS_REGION, spaceMetricsTableName)
-
-  const provisionsStorage = useProvisionStore(subscriptionTable, consumerTable, spaceMetricsTable, parseServiceDids(providers))
-  const subscriptionsStorage = useSubscriptionsStore({ consumerTable })
-  const delegationsStorage = createDelegationsTable(AWS_REGION, delegationTableName, { bucket: delegationBucket })
-  const revocationsStorage = createRevocationsTable(AWS_REGION, revocationTableName)
   const spaceDiffStore = createSpaceDiffStore({ region: AWS_REGION }, { tableName: spaceDiffTableName })
   const spaceSnapshotStore = createSpaceSnapshotStore({ region: AWS_REGION }, { tableName: spaceSnapshotTableName })
   const egressTrafficQueue = createEgressTrafficQueue({ region: AWS_REGION }, { url: new URL(egressTrafficQueueUrl) })
+
   const usageStorage = useUsageStore({ spaceDiffStore, spaceSnapshotStore, egressTrafficQueue })
 
+  const provisionsStorage = useProvisionStore(subscriptionTable, consumerTable, customerStore, usageStorage, parseServiceDids(providers))
+  const subscriptionsStorage = useSubscriptionsStore({ consumerTable })
+  const delegationsStorage = createDelegationsTable(AWS_REGION, delegationTableName, { bucket: delegationBucket })
+  const revocationsStorage = createRevocationsTable(AWS_REGION, revocationTableName)
+  
   const dealTrackerConnection = getServiceConnection({
     did: dealTrackerDid,
     url: dealTrackerUrl

--- a/upload-api/stores/provisions.js
+++ b/upload-api/stores/provisions.js
@@ -1,6 +1,31 @@
+import { cidrSplitToCfnExpression } from 'aws-cdk-lib/aws-ec2'
 import { ConflictError as ConsumerConflictError } from '../tables/consumer.js'
 import { ConflictError as SubscriptionConflictError } from '../tables/subscription.js'
 import { CBOR, Failure } from '@ucanto/server'
+import { productInfo } from '../../billing/lib/product-info.js'
+
+
+/**
+ * @param {string | number | Date} now 
+ */
+const startOfMonth = (now) => {
+  const d = new Date(now)
+  d.setUTCDate(1)
+  d.setUTCHours(0)
+  d.setUTCMinutes(0)
+  d.setUTCSeconds(0)
+  d.setUTCMilliseconds(0)
+  return d
+}
+
+/**
+ * @param {string | number | Date} now 
+ */
+const startOfLastMonth = (now) => {
+  const d = startOfMonth(now)
+  d.setUTCMonth(d.getUTCMonth() - 1)
+  return d
+}
 
 /**
  * Create a subscription ID for a given provision. Currently 
@@ -16,11 +41,12 @@ export const createProvisionSubscriptionId = async ({ customer, consumer }) =>
 /**
  * @param {import('../types.js').SubscriptionTable} subscriptionTable
  * @param {import('../types.js').ConsumerTable} consumerTable
- * @param {import('../types.js').SpaceMetricsTable} spaceMetricsTable
+ * @param {import("../../billing/lib/api.js").CustomerStore} customerStore
+ * @param {import('@storacha/upload-api').UsageStorage} usageStore
  * @param {import('@ucanto/interface').DID<'web'>[]} services
  * @returns {import('@storacha/upload-api').ProvisionsStorage}
  */
-export function useProvisionStore (subscriptionTable, consumerTable, spaceMetricsTable, services) {
+export function useProvisionStore (subscriptionTable, consumerTable, customerStore, usageStore, services) {
   return {
     services,
     hasStorageProvider: async (consumer) => (
@@ -100,21 +126,40 @@ export function useProvisionStore (subscriptionTable, consumerTable, spaceMetric
     },
 
     getConsumer: async (provider, consumer) => {
-      const [consumerRecord, allocated] = await Promise.all([
-        consumerTable.get(provider, consumer),
-        spaceMetricsTable.getAllocated(consumer)
-      ])
-      return consumerRecord ? ({
+      const consumerRecord = await consumerTable.get(provider, consumer)
+      if (!consumerRecord) {
+        return { error: { name: 'ConsumerNotFound', message: `could not find ${consumer}` } }
+      }
+      const planLimitResult = await customerStore.planLimit(consumerRecord.customer)
+      if (planLimitResult.error) {
+        return { error: planLimitResult.error }
+      }
+      const consumerRecords = await consumerTable.listByCustomer(consumerRecord.customer)
+      let totalUsage = 0
+      for (const consumer of consumerRecords.results) {
+        const now = new Date()
+        const spaceUsage = await usageStore.report(consumer.provider, consumer.consumer, {
+          // we may not have done a snapshot for this month _yet_, so get report
+          // from last month -> now
+          from: startOfLastMonth(now),
+          to: now,
+        })
+
+        if (spaceUsage.error) {
+          return { error: { name: 'UsageReportError', message: `could not get usage report for ${consumer.consumer}`, cause: spaceUsage.error } }
+        }
+        totalUsage += spaceUsage.ok.size.final
+      }
+
+      return ({
         ok: {
           did: consumer,
-          allocated,
-          limit: 1_000_000_000, // set to an arbitrarily high number because we currently don't enforce any limits
+          allocated: totalUsage, // set to 0 because we currently don't track allocated space
+          limit: planLimitResult.ok,
           subscription: consumerRecord.subscription,
           customer: consumerRecord.customer
         }
-      }) : (
-        { error: { name: 'ConsumerNotFound', message: `could not find ${consumer}` } }
-      )
+      })
     },
 
     getSubscription: async (provider, subscription) => {


### PR DESCRIPTION
# Goals

Enable plans to have enforced limits

# Implementation

- mark plans as allowing overages or not (all current plans for now allow overages)
- add a planLimit lookup based on customer ID which returns a value if an only if a customer has a plan that does not allow overages
- add code to calculate total space used in getConsumer properly, and also add call to get plan limit
- requires shifting around a bunch of dependencies
- pairs with https://github.com/storacha/upload-service/pull/386

# For discussion

I see two potential concerns with the proposed approach:

1. While the using the fields of allocated and limit is convenient cause they already exist, it leads to pretty big mixing of concerns, and a call to getConsumer that does a lot of calculation. It seems to me there should be a function/class that uses the provisionStore and the usageStore to provide a higher level call to get the usage + limit. Also perhaps usage per account should move into the usageStore per https://github.com/storacha/RFC/pull/64
2. Regardless of code quality, I'm concerned about performance calculating usage. I guess one move would be to not calculate usage UNLESS there's a limit on the plan. Again, this seems like it really just needs a different API than getConsumer, even if that was convenient to implement inside spaceAllocate. Is there a way we can cache current usage numbers? It seems like a weird thing to not be able to calculate. Especially since this is really a different question than billing: it's about the total current space used.
